### PR TITLE
Fix: fatal error in jp4wc_delivery_check_data causing duplicate orders on Classic Checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ Thumbs.db
 
 # claude settings
 .claude/settings.local.json
+
+# e2e test artifacts
+tests/e2e/reports/
+tests/e2e/.auth/
+playwright-report/
+test-results/

--- a/includes/blocks/class-jp4wc-delivery-blocks-integration.php
+++ b/includes/blocks/class-jp4wc-delivery-blocks-integration.php
@@ -161,7 +161,7 @@ class JP4WC_Delivery_Blocks_Integration implements IntegrationInterface {
 				$this->log_info( 'ERROR registering delivery date field: ' . $e->getMessage() );
 			}
 		} else {
-			$this->log_info( 'Delivery date field NOT registered. Option: ' . get_option( 'wc4jp-delivery-date' ) . ', Dates: ' . count( $delivery_dates ) );
+			$this->log_debug( 'Delivery date field NOT registered. Option: ' . get_option( 'wc4jp-delivery-date' ) . ', Dates: ' . count( $delivery_dates ) );
 		}
 
 		// Register delivery time field as select.
@@ -187,7 +187,7 @@ class JP4WC_Delivery_Blocks_Integration implements IntegrationInterface {
 				$this->log_info( 'ERROR registering delivery time field: ' . $e->getMessage() );
 			}
 		} else {
-			$this->log_info( 'Delivery time field NOT registered. Option: ' . get_option( 'wc4jp-delivery-time-zone' ) . ', Zones: ' . count( $time_zones ) );
+			$this->log_debug( 'Delivery time field NOT registered. Option: ' . get_option( 'wc4jp-delivery-time-zone' ) . ', Zones: ' . count( $time_zones ) );
 		}
 
 		// Flag already set at the beginning of this method.
@@ -486,6 +486,21 @@ class JP4WC_Delivery_Blocks_Integration implements IntegrationInterface {
 		if ( function_exists( 'wc_get_logger' ) ) {
 			$logger = wc_get_logger();
 			$logger->info(
+				'[JP4WC Delivery Blocks] ' . $message,
+				array( 'source' => 'jp4wc_delivery_block' )
+			);
+		}
+	}
+
+	/**
+	 * Log debug message — only outputs when WP_DEBUG is enabled.
+	 *
+	 * @param string $message Message to log.
+	 */
+	private function log_debug( $message ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'wc_get_logger' ) ) {
+			$logger = wc_get_logger();
+			$logger->debug(
 				'[JP4WC Delivery Blocks] ' . $message,
 				array( 'source' => 'jp4wc_delivery_block' )
 			);

--- a/includes/class-jp4wc-delivery.php
+++ b/includes/class-jp4wc-delivery.php
@@ -44,9 +44,11 @@ class JP4WC_Delivery {
 		add_action( 'woocommerce_order_details_after_order_table', array( $this, 'frontend_order_timedate' ) );
 		// Show on order detail email (frontend).
 		add_filter( 'woocommerce_email_order_meta', array( $this, 'email_order_delivery_details' ), 10, 3 );
-		// Shop Order functions.
+		// Shop Order functions — legacy post list and HPOS order list.
 		add_filter( 'manage_edit-shop_order_columns', array( $this, 'shop_order_columns' ) );
 		add_action( 'manage_shop_order_posts_custom_column', array( $this, 'render_shop_order_columns' ), 2 );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'shop_order_columns' ) );
+		add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'render_hpos_shop_order_columns' ), 2, 2 );
 		// display in Order meta box ship date and time (admin).
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'save_meta_box' ), 0, 1 );
@@ -767,6 +769,18 @@ class JP4WC_Delivery {
 				break;
 		}
 	}
+	/**
+	 * Admin: Output delivery column on HPOS order list.
+	 *
+	 * @param string   $column Column ID.
+	 * @param WC_Order $order  Order object passed by HPOS action.
+	 */
+	public function render_hpos_shop_order_columns( $column, $order ) {
+		if ( 'wc4jp_delivery' === $column ) {
+			$this->display_date_and_time_zone( $order );
+		}
+	}
+
 	/**
 	 * Admin: Display date and timeslot on the admin order page
 	 *

--- a/includes/class-jp4wc-delivery.php
+++ b/includes/class-jp4wc-delivery.php
@@ -51,7 +51,7 @@ class JP4WC_Delivery {
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'save_meta_box' ), 0, 1 );
 
-		add_filter( 'woocommerce_payment_successful_result', array( $this, 'jp4wc_delivery_check_data' ), 10, 1 );
+		add_filter( 'woocommerce_payment_successful_result', array( $this, 'jp4wc_delivery_check_data' ), 10, 2 );
 	}
 
 	/**
@@ -922,12 +922,15 @@ class JP4WC_Delivery {
 	/**
 	 * Check delivery date data after successful payment and send admin notification if required date is missing.
 	 *
-	 * @param array $result Payment successful result.
+	 * @param array $result   Payment successful result.
+	 * @param int   $order_id Order ID passed by WooCommerce as the second filter argument.
 	 * @return array Modified payment result.
 	 */
-	public function jp4wc_delivery_check_data( $result ) {
-		$order_id = $result['order_id'];
-		$order    = wc_get_order( $order_id );
+	public function jp4wc_delivery_check_data( $result, $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return $result;
+		}
 
 		// Check both shortcode and Checkout Block meta keys for delivery date.
 		$date = $order->get_meta( 'wc4jp-delivery-date', true );

--- a/package.json
+++ b/package.json
@@ -10,12 +10,18 @@
 		"npm": "^10.5.0"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
+		"@types/node": "^25.6.0",
 		"@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
 		"@woocommerce/eslint-plugin": "^2.3.0",
 		"@wordpress/scripts": "^30.19.0",
 		"cross-env": "7.0.3"
 	},
 	"scripts": {
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:debug": "playwright test --debug",
+		"test:e2e:report": "playwright show-report tests/e2e/reports",
 		"start": "wp-scripts start",
 		"build": "wp-scripts build && npm run i18n:build",
 		"i18n": "npm run i18n:build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL: string = ( process.env.WP_BASE_URL as string | undefined ) ?? 'http://localhost:8891';
+
+export default defineConfig({
+	testDir: './tests/e2e',
+	timeout: 60_000,
+	expect: { timeout: 10_000 },
+	globalSetup: require.resolve( './tests/e2e/global-setup' ),
+	fullyParallel: false,
+	forbidOnly: !!( process.env.CI as string | undefined ),
+	retries: ( process.env.CI as string | undefined ) ? 1 : 0,
+	workers: 1,
+	reporter: [ [ 'list' ], [ 'html', { open: 'never', outputFolder: 'tests/e2e/reports' } ] ],
+	use: {
+		baseURL: BASE_URL,
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		video: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+	],
+} );

--- a/tests/Unit/test-jp4wc-delivery-blocks-validation.php
+++ b/tests/Unit/test-jp4wc-delivery-blocks-validation.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Tests for JP4WC_Delivery_Blocks_Integration field validation
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * Unit tests for JP4WC_Delivery_Blocks_Integration::validate_additional_field().
+ *
+ * This validator runs on every Store API request (calc_totals, locale, final checkout),
+ * so the calc_totals guard is critical to prevent 500 errors on intermediate updates.
+ */
+class JP4WC_Delivery_Blocks_Validation_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var JP4WC_Delivery_Blocks_Integration
+	 */
+	private $integration;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( 'JP4WC_Delivery_Blocks_Integration' ) ) {
+			require_once dirname( __DIR__, 2 ) . '/includes/blocks/class-jp4wc-delivery-blocks-integration.php';
+		}
+
+		if ( ! class_exists( 'JP4WC_Delivery_Blocks_Integration' ) ) {
+			$this->markTestSkipped( 'JP4WC_Delivery_Blocks_Integration not available (WC Blocks interface missing)' );
+		}
+
+		$this->integration = new JP4WC_Delivery_Blocks_Integration();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wc4jp-delivery-date-required' );
+		delete_option( 'wc4jp-delivery-time-zone-required' );
+		unset( $_GET['__experimental_calc_totals'], $_GET['_locale'] );
+	}
+
+	// ------------------------------------------------------------------
+	// calc_totals / locale guard
+	// ------------------------------------------------------------------
+
+	/**
+	 * calc_totals request → validation skipped, $is_valid returned unchanged.
+	 */
+	public function test_skips_validation_on_calc_totals_request() {
+		$_GET['__experimental_calc_totals'] = '1';
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', '' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * calc_totals with $is_valid=false → still returned unchanged (no WP_Error).
+	 */
+	public function test_skips_validation_on_calc_totals_preserves_false() {
+		$_GET['__experimental_calc_totals'] = '1';
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( false, 'jp4wc/delivery-date', '' );
+
+		$this->assertFalse( $result );
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+	}
+
+	// ------------------------------------------------------------------
+	// Delivery date validation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Delivery date required, value empty → WP_Error returned.
+	 */
+	public function test_returns_error_when_required_date_is_empty() {
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', '' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'invalid_delivery_date', $result->get_error_code() );
+	}
+
+	/**
+	 * Delivery date required, value is null → WP_Error returned.
+	 */
+	public function test_returns_error_when_required_date_is_null() {
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', null );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Delivery date required, value is '0' (unspecified) → WP_Error returned.
+	 */
+	public function test_returns_error_when_required_date_is_zero() {
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', '0' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Delivery date required, value present → $is_valid returned unchanged.
+	 */
+	public function test_passes_when_required_date_is_present() {
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', '2026-05-10' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Delivery date not required → passes even when empty.
+	 */
+	public function test_passes_when_date_is_not_required_and_empty() {
+		update_option( 'wc4jp-delivery-date-required', '0' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-date', '' );
+
+		$this->assertTrue( $result );
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+	}
+
+	// ------------------------------------------------------------------
+	// Delivery time validation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Delivery time required, value empty → WP_Error returned.
+	 */
+	public function test_returns_error_when_required_time_is_empty() {
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-time', '' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'invalid_delivery_time', $result->get_error_code() );
+	}
+
+	/**
+	 * Delivery time required, value present → passes.
+	 */
+	public function test_passes_when_required_time_is_present() {
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-time', '14:00-16:00' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Delivery time not required, empty → passes.
+	 */
+	public function test_passes_when_time_is_not_required_and_empty() {
+		update_option( 'wc4jp-delivery-time-zone-required', '0' );
+
+		$result = $this->integration->validate_additional_field( true, 'jp4wc/delivery-time', '' );
+
+		$this->assertTrue( $result );
+	}
+
+	// ------------------------------------------------------------------
+	// Unrelated field key
+	// ------------------------------------------------------------------
+
+	/**
+	 * Unrelated field key → $is_valid returned unchanged without any check.
+	 */
+	public function test_passes_unrelated_field_key_unchanged() {
+		$result = $this->integration->validate_additional_field( true, 'some/other-field', '' );
+
+		$this->assertTrue( $result );
+	}
+
+	// ------------------------------------------------------------------
+	// hide_additional_fields_from_order_meta
+	// ------------------------------------------------------------------
+
+	/**
+	 * JP4WC delivery meta keys are removed from formatted order meta.
+	 */
+	public function test_hides_delivery_meta_keys_from_order_display() {
+		$order = wc_create_order();
+
+		$date_meta          = new stdClass();
+		$date_meta->key     = '_wc_other/jp4wc/delivery-date';
+		$date_meta->value   = '2026-05-10';
+
+		$time_meta          = new stdClass();
+		$time_meta->key     = '_wc_other/jp4wc/delivery-time';
+		$time_meta->value   = '10:00-12:00';
+
+		$other_meta         = new stdClass();
+		$other_meta->key    = '_billing_first_name';
+		$other_meta->value  = 'Shohei';
+
+		$formatted = array( 1 => $date_meta, 2 => $time_meta, 3 => $other_meta );
+		$result    = $this->integration->hide_additional_fields_from_order_meta( $formatted, $order );
+
+		$this->assertArrayNotHasKey( 1, $result, 'delivery-date meta should be hidden' );
+		$this->assertArrayNotHasKey( 2, $result, 'delivery-time meta should be hidden' );
+		$this->assertArrayHasKey( 3, $result, 'unrelated meta should remain' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * No JP4WC keys in formatted meta → array returned unchanged.
+	 */
+	public function test_leaves_non_jp4wc_meta_unchanged() {
+		$order = wc_create_order();
+
+		$meta       = new stdClass();
+		$meta->key  = '_billing_first_name';
+		$meta->value = 'Test';
+
+		$formatted = array( 1 => $meta );
+		$result    = $this->integration->hide_additional_fields_from_order_meta( $formatted, $order );
+
+		$this->assertCount( 1, $result );
+
+		$order->delete( true );
+	}
+}

--- a/tests/Unit/test-jp4wc-delivery-payment.php
+++ b/tests/Unit/test-jp4wc-delivery-payment.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Tests for jp4wc_delivery_check_data (woocommerce_payment_successful_result filter)
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * Regression and unit tests for JP4WC_Delivery::jp4wc_delivery_check_data().
+ *
+ * Covers the bug where $result['order_id'] was undefined for Square/Amazon Pay,
+ * causing a PHP Fatal Error after a successful payment and preventing the browser
+ * from redirecting to the Thank You page.
+ */
+class JP4WC_Delivery_Payment_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var JP4WC_Delivery
+	 */
+	private $delivery;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->delivery = new JP4WC_Delivery();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wc4jp-delivery-date' );
+		delete_option( 'wc4jp-delivery-date-required' );
+		delete_option( 'wc4jp-delivery-time-zone' );
+		delete_option( 'wc4jp-delivery-time-zone-required' );
+	}
+
+	/**
+	 * Create a saved WC_Order for use in tests.
+	 */
+	private function create_order(): WC_Order {
+		$order = wc_create_order();
+		$order->set_billing_email( 'test@example.com' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Build a minimal payment result array (as returned by process_payment).
+	 * Intentionally does NOT include 'order_id' — this matches Square/Amazon Pay.
+	 */
+	private function make_result( string $status = 'success' ): array {
+		return array(
+			'result'   => $status,
+			'redirect' => 'https://example.com/order-received/',
+		);
+	}
+
+	/**
+	 * Confirm the filter is registered with 2 accepted arguments.
+	 * Regression: was registered with 1, so $order_id was never received.
+	 */
+	public function test_filter_registered_with_two_args() {
+		global $wp_filter;
+		$hooks = $wp_filter['woocommerce_payment_successful_result'] ?? null;
+		$this->assertNotNull( $hooks, 'Filter woocommerce_payment_successful_result should be registered' );
+
+		$found = false;
+		foreach ( $hooks->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $cb ) {
+				if (
+					is_array( $cb['function'] ) &&
+					$cb['function'][0] instanceof JP4WC_Delivery &&
+					$cb['function'][1] === 'jp4wc_delivery_check_data'
+				) {
+					$this->assertSame( 2, $cb['accepted_args'], 'Filter must accept 2 arguments to receive $order_id' );
+					$found = true;
+				}
+			}
+		}
+		$this->assertTrue( $found, 'jp4wc_delivery_check_data callback should be registered' );
+	}
+
+	/**
+	 * Delivery options disabled → result is returned unchanged.
+	 */
+	public function test_returns_result_unchanged_when_delivery_disabled() {
+		$order  = $this->create_order();
+		$result = $this->make_result();
+
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'success', $returned['result'] );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Regression: Square/Amazon Pay style result (no 'order_id' key) must not cause a
+	 * Fatal Error. The $order_id arrives as the second filter argument, not in $result.
+	 */
+	public function test_square_style_result_without_order_id_key_causes_no_error() {
+		$order = $this->create_order();
+
+		// Intentionally no 'order_id' in the result array — matches real gateway output.
+		$result   = array( 'result' => 'success', 'redirect' => 'https://example.com/' );
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'success', $returned['result'] );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Non-existent order_id → early return without Fatal Error.
+	 */
+	public function test_returns_result_when_order_not_found() {
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, 999999999 );
+
+		$this->assertSame( 'success', $returned['result'] );
+	}
+
+	/**
+	 * order_id = 0 (another edge case from undefined key) → early return without Fatal Error.
+	 */
+	public function test_returns_result_when_order_id_is_zero() {
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, 0 );
+
+		$this->assertSame( 'success', $returned['result'] );
+	}
+
+	/**
+	 * Delivery date required, date present → passes through as success.
+	 */
+	public function test_passes_when_required_date_is_present() {
+		$order = $this->create_order();
+		$order->update_meta_data( 'wc4jp-delivery-date', '2026-05-10' );
+		$order->save();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'success', $returned['result'] );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Delivery date required, date missing → result becomes 'failure' and order is marked failed.
+	 */
+	public function test_fails_when_required_date_missing() {
+		$order = $this->create_order();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'failure', $returned['result'] );
+		$this->assertArrayHasKey( 'messages', $returned );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'failed', $refreshed->get_status() );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Delivery time required, time missing → result becomes 'failure'.
+	 */
+	public function test_fails_when_required_time_missing() {
+		$order = $this->create_order();
+
+		update_option( 'wc4jp-delivery-time-zone', '1' );
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'failure', $returned['result'] );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Delivery date option disabled (empty) even if required flag is set → passes.
+	 * This matches the reported site where Option: '' but Dates: 8.
+	 */
+	public function test_passes_when_delivery_date_option_is_disabled() {
+		$order = $this->create_order();
+
+		update_option( 'wc4jp-delivery-date', '' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'success', $returned['result'] );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Both date and time required, both missing → single 'failure' with order marked failed once.
+	 */
+	public function test_fails_once_when_both_date_and_time_required_and_missing() {
+		$order = $this->create_order();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+		update_option( 'wc4jp-delivery-time-zone', '1' );
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$result   = $this->make_result();
+		$returned = $this->delivery->jp4wc_delivery_check_data( $result, $order->get_id() );
+
+		$this->assertSame( 'failure', $returned['result'] );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'failed', $refreshed->get_status() );
+
+		$order->delete( true );
+	}
+}

--- a/tests/Unit/test-jp4wc-delivery-saving.php
+++ b/tests/Unit/test-jp4wc-delivery-saving.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Tests for JP4WC_Delivery data saving to order meta
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * Unit tests for JP4WC_Delivery::save_delivery_data_to_order().
+ */
+class JP4WC_Delivery_Saving_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var JP4WC_Delivery
+	 */
+	private $delivery;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->delivery = new JP4WC_Delivery();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wc4jp-date-format' );
+	}
+
+	/**
+	 * Create a saved WC_Order for use in tests.
+	 */
+	private function create_order(): WC_Order {
+		$order = wc_create_order();
+		$order->set_billing_email( 'test@example.com' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Delivery date in $data → saved to order meta.
+	 */
+	public function test_saves_delivery_date_to_order_meta() {
+		$order = $this->create_order();
+		$data  = array( 'wc4jp_delivery_date' => '2026-05-10' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( '2026-05-10', $refreshed->get_meta( 'wc4jp-delivery-date', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Delivery time zone in $data → saved to order meta.
+	 */
+	public function test_saves_delivery_time_to_order_meta() {
+		$order = $this->create_order();
+		$data  = array( 'wc4jp_delivery_time_zone' => '14:00-16:00' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( '14:00-16:00', $refreshed->get_meta( 'wc4jp-delivery-time-zone', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Both date and time in $data → both saved correctly.
+	 */
+	public function test_saves_both_date_and_time() {
+		$order = $this->create_order();
+		$data  = array(
+			'wc4jp_delivery_date'      => '2026-05-15',
+			'wc4jp_delivery_time_zone' => '10:00-12:00',
+		);
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( '2026-05-15', $refreshed->get_meta( 'wc4jp-delivery-date', true ) );
+		$this->assertSame( '10:00-12:00', $refreshed->get_meta( 'wc4jp-delivery-time-zone', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Empty $data → nothing saved, existing meta unchanged.
+	 */
+	public function test_does_not_save_when_data_is_empty() {
+		$order = $this->create_order();
+		$order->update_meta_data( 'wc4jp-delivery-date', 'existing-value' );
+		$order->save();
+
+		$this->delivery->save_delivery_data_to_order( $order, array() );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'existing-value', $refreshed->get_meta( 'wc4jp-delivery-date', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Date value is '0' (unspecified selection) → not saved to order meta.
+	 */
+	public function test_does_not_save_date_when_value_is_zero() {
+		$order = $this->create_order();
+		$data  = array( 'wc4jp_delivery_date' => '0' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $refreshed->get_meta( 'wc4jp-delivery-date', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Time value is '0' → not saved.
+	 */
+	public function test_does_not_save_time_when_value_is_zero() {
+		$order = $this->create_order();
+		$data  = array( 'wc4jp_delivery_time_zone' => '0' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $refreshed->get_meta( 'wc4jp-delivery-time-zone', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * When wc4jp-date-format option is set, the date is reformatted before saving.
+	 */
+	public function test_applies_date_format_when_option_is_set() {
+		$order = $this->create_order();
+		update_option( 'wc4jp-date-format', 'Y年m月d日' );
+
+		$data = array( 'wc4jp_delivery_date' => '2026-05-10' );
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$saved     = $refreshed->get_meta( 'wc4jp-delivery-date', true );
+
+		// Should be formatted, not the raw Y-m-d input.
+		$this->assertNotSame( '2026-05-10', $saved );
+		$this->assertStringContainsString( '2026', $saved );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Block checkout path → save_delivery_data_to_order skips execution.
+	 * Block checkout is detected via did_action('woocommerce_store_api_checkout_update_order_from_request').
+	 */
+	public function test_skips_save_on_block_checkout() {
+		// Simulate block checkout having fired (pass required 2 args to satisfy registered callbacks).
+		do_action( 'woocommerce_store_api_checkout_update_order_from_request', new WC_Order(), new WP_REST_Request() );
+
+		$order = $this->create_order();
+		$data  = array( 'wc4jp_delivery_date' => '2026-05-20' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $refreshed->get_meta( 'wc4jp-delivery-date', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Tracking ship date in $data → saved to order meta.
+	 */
+	public function test_saves_tracking_ship_date() {
+		$order = $this->create_order();
+		$data  = array( 'wc4jp-tracking-ship-date' => '2026-05-12' );
+
+		$this->delivery->save_delivery_data_to_order( $order, $data );
+		$order->save();
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( '2026-05-12', $refreshed->get_meta( 'wc4jp-tracking-ship-date', true ) );
+
+		$order->delete( true );
+	}
+}

--- a/tests/Unit/test-jp4wc-delivery-validation.php
+++ b/tests/Unit/test-jp4wc-delivery-validation.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Tests for JP4WC_Delivery checkout field validation (Classic Checkout)
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * Unit tests for JP4WC_Delivery::validate_date_time_checkout_field().
+ */
+class JP4WC_Delivery_Validation_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var JP4WC_Delivery
+	 */
+	private $delivery;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->delivery = new JP4WC_Delivery();
+
+		// Set a logged-in user so wp_create_nonce works.
+		wp_set_current_user( 1 );
+
+		// Set up WooCommerce cart.
+		WC()->cart->empty_cart();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wc4jp-delivery-date' );
+		delete_option( 'wc4jp-delivery-date-required' );
+		delete_option( 'wc4jp-delivery-time-zone' );
+		delete_option( 'wc4jp-delivery-time-zone-required' );
+
+		// Clear POST data.
+		$_POST = array();
+
+		WC()->cart->empty_cart();
+	}
+
+	/**
+	 * Add a physical product to the cart so validation is not skipped.
+	 */
+	private function add_physical_product_to_cart(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Physical Product' );
+		$product->set_regular_price( '1000' );
+		$product->set_virtual( false );
+		$product_id = $product->save();
+		WC()->cart->add_to_cart( $product_id );
+	}
+
+	/**
+	 * Set a valid WooCommerce checkout nonce in $_POST.
+	 */
+	private function set_valid_nonce(): void {
+		$_POST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
+	}
+
+	/**
+	 * No nonce in $_POST → validation skips entirely, no errors added.
+	 */
+	public function test_skips_validation_when_nonce_missing() {
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertEmpty( $errors->get_error_codes() );
+	}
+
+	/**
+	 * Invalid nonce → validation skips entirely, no errors added.
+	 */
+	public function test_skips_validation_when_nonce_invalid() {
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$_POST['woocommerce-process-checkout-nonce'] = 'invalid_nonce';
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertEmpty( $errors->get_error_codes() );
+	}
+
+	/**
+	 * Cart has only virtual products → validation skips, no errors added.
+	 */
+	public function test_skips_validation_for_virtual_products_only() {
+		$this->set_valid_nonce();
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Virtual Product' );
+		$product->set_regular_price( '500' );
+		$product->set_virtual( true );
+		$product_id = $product->save();
+		WC()->cart->add_to_cart( $product_id );
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertEmpty( $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery date option disabled → no error even if field is empty.
+	 */
+	public function test_no_error_when_delivery_date_option_disabled() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertNotContains( 'wc4jp_delivery_date_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery date required, date present in $fields → no error.
+	 */
+	public function test_no_error_when_required_date_present_in_fields() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$fields = array( 'wc4jp_delivery_date' => '2026-05-10' );
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( $fields, $errors );
+
+		$this->assertNotContains( 'wc4jp_delivery_date_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery date required, field missing → error added.
+	 */
+	public function test_adds_error_when_required_date_missing() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertContains( 'wc4jp_delivery_date_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery date required, value is '0' (unspecified) → error added.
+	 */
+	public function test_adds_error_when_date_value_is_zero() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+
+		$fields = array( 'wc4jp_delivery_date' => '0' );
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( $fields, $errors );
+
+		$this->assertContains( 'wc4jp_delivery_date_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery date not required → no error even if field is empty.
+	 */
+	public function test_no_error_when_date_is_optional_and_missing() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '0' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertNotContains( 'wc4jp_delivery_date_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery time required, time zone missing → error added.
+	 */
+	public function test_adds_error_when_required_time_missing() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-time-zone', '1' );
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$this->assertContains( 'wc4jp_delivery_time_zone_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Delivery time required, value present → no error.
+	 */
+	public function test_no_error_when_required_time_present() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-time-zone', '1' );
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$fields = array( 'wc4jp_delivery_time_zone' => '10:00-12:00' );
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( $fields, $errors );
+
+		$this->assertNotContains( 'wc4jp_delivery_time_zone_required', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Both date and time required, both missing → both errors added.
+	 */
+	public function test_adds_both_errors_when_both_required_and_both_missing() {
+		$this->set_valid_nonce();
+		$this->add_physical_product_to_cart();
+
+		update_option( 'wc4jp-delivery-date', '1' );
+		update_option( 'wc4jp-delivery-date-required', '1' );
+		update_option( 'wc4jp-delivery-time-zone', '1' );
+		update_option( 'wc4jp-delivery-time-zone-required', '1' );
+
+		$errors = new WP_Error();
+		$this->delivery->validate_date_time_checkout_field( array(), $errors );
+
+		$codes = $errors->get_error_codes();
+		$this->assertContains( 'wc4jp_delivery_date_required', $codes );
+		$this->assertContains( 'wc4jp_delivery_time_zone_required', $codes );
+	}
+}

--- a/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
+++ b/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Tests for JP4WC_Yomigana_Blocks_Integration
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * Unit tests for JP4WC_Yomigana_Blocks_Integration.
+ *
+ * Covers:
+ *  - validate_additional_field: required/optional, billing keys, unrelated keys
+ *  - hide_additional_fields_from_order_meta: all four yomigana WC meta keys
+ *  - save_to_order_meta: billing and shipping yomigana saved from REST request
+ *  - filter_order_confirmation_address_block: strips dt/dd from rendered HTML
+ */
+class JP4WC_Yomigana_Blocks_Validation_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var JP4WC_Yomigana_Blocks_Integration
+	 */
+	private $integration;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( 'JP4WC_Yomigana_Blocks_Integration' ) ) {
+			require_once dirname( __DIR__, 2 ) . '/includes/blocks/class-jp4wc-yomigana-blocks-integration.php';
+		}
+
+		if ( ! class_exists( 'JP4WC_Yomigana_Blocks_Integration' ) ) {
+			$this->markTestSkipped( 'JP4WC_Yomigana_Blocks_Integration not available (WC Blocks interface missing)' );
+		}
+
+		$this->integration = new JP4WC_Yomigana_Blocks_Integration();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wc4jp-yomigana' );
+		delete_option( 'wc4jp-yomigana-required' );
+	}
+
+	// ------------------------------------------------------------------
+	// validate_additional_field
+	// ------------------------------------------------------------------
+
+	/**
+	 * Yomigana required, billing last name empty → WP_Error.
+	 */
+	public function test_returns_error_when_required_billing_last_name_empty() {
+		update_option( 'wc4jp-yomigana-required', '1' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_billing/jp4wc/yomigana_last_name',
+			''
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'invalid_yomigana', $result->get_error_code() );
+	}
+
+	/**
+	 * Yomigana required, billing first name empty → WP_Error.
+	 */
+	public function test_returns_error_when_required_billing_first_name_empty() {
+		update_option( 'wc4jp-yomigana-required', '1' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_billing/jp4wc/yomigana_first_name',
+			''
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'invalid_yomigana', $result->get_error_code() );
+	}
+
+	/**
+	 * Yomigana required, value present → $is_valid returned unchanged.
+	 */
+	public function test_passes_when_required_yomigana_is_present() {
+		update_option( 'wc4jp-yomigana-required', '1' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_billing/jp4wc/yomigana_last_name',
+			'タナカ'
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Yomigana not required, value empty → passes.
+	 */
+	public function test_passes_when_yomigana_not_required_and_empty() {
+		update_option( 'wc4jp-yomigana-required', '0' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_billing/jp4wc/yomigana_last_name',
+			''
+		);
+
+		$this->assertTrue( $result );
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Unrelated field key → $is_valid returned unchanged without any check.
+	 */
+	public function test_passes_unrelated_field_key() {
+		update_option( 'wc4jp-yomigana-required', '1' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_billing/some/other-field',
+			''
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Shipping yomigana keys are NOT in the validation list → pass through.
+	 * Shipping fields use _wc_shipping/ prefix, which is intentionally outside
+	 * the billing-only validation scope.
+	 */
+	public function test_shipping_keys_are_not_validated() {
+		update_option( 'wc4jp-yomigana-required', '1' );
+
+		$result = $this->integration->validate_additional_field(
+			true,
+			'_wc_shipping/jp4wc/yomigana_last_name',
+			''
+		);
+
+		$this->assertTrue( $result );
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+	}
+
+	// ------------------------------------------------------------------
+	// hide_additional_fields_from_order_meta
+	// ------------------------------------------------------------------
+
+	/**
+	 * All four yomigana WC meta keys are removed from formatted order meta.
+	 */
+	public function test_hides_all_four_yomigana_meta_keys() {
+		$order = wc_create_order();
+
+		$keys_to_hide = array(
+			'_wc_billing/jp4wc/yomigana_last_name',
+			'_wc_billing/jp4wc/yomigana_first_name',
+			'_wc_shipping/jp4wc/yomigana_last_name',
+			'_wc_shipping/jp4wc/yomigana_first_name',
+		);
+
+		$formatted = array();
+		foreach ( $keys_to_hide as $i => $key ) {
+			$meta        = new stdClass();
+			$meta->key   = $key;
+			$meta->value = 'テスト';
+			$formatted[ $i ] = $meta;
+		}
+
+		// Add an unrelated meta entry.
+		$other        = new stdClass();
+		$other->key   = '_billing_first_name';
+		$other->value = 'Shohei';
+		$formatted[99] = $other;
+
+		$result = $this->integration->hide_additional_fields_from_order_meta( $formatted, $order );
+
+		foreach ( array( 0, 1, 2, 3 ) as $idx ) {
+			$this->assertArrayNotHasKey( $idx, $result, "Key {$keys_to_hide[$idx]} should be hidden" );
+		}
+		$this->assertArrayHasKey( 99, $result, 'Unrelated meta should remain' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * No yomigana keys → array returned unchanged.
+	 */
+	public function test_leaves_non_yomigana_meta_unchanged() {
+		$order = wc_create_order();
+
+		$meta        = new stdClass();
+		$meta->key   = '_billing_address_1';
+		$meta->value = '1-1-1 Shibuya';
+		$formatted   = array( 1 => $meta );
+
+		$result = $this->integration->hide_additional_fields_from_order_meta( $formatted, $order );
+
+		$this->assertCount( 1, $result );
+
+		$order->delete( true );
+	}
+
+	// ------------------------------------------------------------------
+	// save_to_order_meta
+	// ------------------------------------------------------------------
+
+	/**
+	 * Billing yomigana fields from REST request are saved to order meta.
+	 */
+	public function test_saves_billing_yomigana_from_request() {
+		$order   = wc_create_order();
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_param(
+			'billing_address',
+			array(
+				'additional_fields' => array(
+					'jp4wc/yomigana_last_name'  => 'タナカ',
+					'jp4wc/yomigana_first_name' => 'ショウヘイ',
+				),
+			)
+		);
+
+		$this->integration->save_to_order_meta( $order, $request );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'タナカ', $refreshed->get_meta( '_billing_yomigana_last_name', true ) );
+		$this->assertSame( 'ショウヘイ', $refreshed->get_meta( '_billing_yomigana_first_name', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Shipping yomigana fields from REST request are saved to order meta.
+	 */
+	public function test_saves_shipping_yomigana_from_request() {
+		$order   = wc_create_order();
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_param(
+			'shipping_address',
+			array(
+				'additional_fields' => array(
+					'jp4wc/yomigana_last_name'  => 'ヤマダ',
+					'jp4wc/yomigana_first_name' => 'タロウ',
+				),
+			)
+		);
+
+		$this->integration->save_to_order_meta( $order, $request );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'ヤマダ', $refreshed->get_meta( '_shipping_yomigana_last_name', true ) );
+		$this->assertSame( 'タロウ', $refreshed->get_meta( '_shipping_yomigana_first_name', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Request with no billing/shipping params → no meta saved, no error.
+	 */
+	public function test_save_does_nothing_when_request_has_no_address_params() {
+		$order   = wc_create_order();
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+
+		$this->integration->save_to_order_meta( $order, $request );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $refreshed->get_meta( '_billing_yomigana_last_name', true ) );
+		$this->assertEmpty( $refreshed->get_meta( '_shipping_yomigana_last_name', true ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Input is sanitized: HTML tags in yomigana value are stripped.
+	 */
+	public function test_sanitizes_yomigana_value_on_save() {
+		$order   = wc_create_order();
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_param(
+			'billing_address',
+			array(
+				'additional_fields' => array(
+					'jp4wc/yomigana_last_name' => '<script>alert(1)</script>タナカ',
+				),
+			)
+		);
+
+		$this->integration->save_to_order_meta( $order, $request );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$saved     = $refreshed->get_meta( '_billing_yomigana_last_name', true );
+
+		$this->assertStringNotContainsString( '<script>', $saved );
+		$this->assertStringContainsString( 'タナカ', $saved );
+
+		$order->delete( true );
+	}
+
+	// ------------------------------------------------------------------
+	// filter_order_confirmation_address_block
+	// ------------------------------------------------------------------
+
+	/**
+	 * Yomigana dt/dd pairs are stripped from rendered block HTML.
+	 */
+	public function test_strips_yomigana_entries_from_block_html() {
+		$label_last  = esc_html( __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ) );
+		$label_first = esc_html( __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ) );
+
+		$html = '<dl class="wc-block-order-confirmation-totals__table">'
+			. "<dt>{$label_last}</dt><dd>タナカ</dd>"
+			. "<dt>{$label_first}</dt><dd>ショウヘイ</dd>"
+			. '<dt>City</dt><dd>Tokyo</dd>'
+			. '</dl>';
+
+		$result = $this->integration->filter_order_confirmation_address_block( $html );
+
+		$this->assertStringNotContainsString( $label_last, $result );
+		$this->assertStringNotContainsString( $label_first, $result );
+		$this->assertStringContainsString( 'Tokyo', $result );
+	}
+
+	/**
+	 * Block HTML with no yomigana entries → returned unchanged.
+	 */
+	public function test_returns_block_html_unchanged_when_no_yomigana() {
+		$html   = '<dl><dt>City</dt><dd>Osaka</dd></dl>';
+		$result = $this->integration->filter_order_confirmation_address_block( $html );
+
+		$this->assertSame( $html, $result );
+	}
+
+	/**
+	 * Empty <dl> wrapper is removed after all yomigana entries are stripped.
+	 */
+	public function test_removes_empty_dl_wrapper_after_stripping() {
+		$label = esc_html( __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ) );
+		$html  = "<dl class=\"extra\"><dt>{$label}</dt><dd>タナカ</dd></dl>";
+
+		$result = $this->integration->filter_order_confirmation_address_block( $html );
+
+		$this->assertStringNotContainsString( '<dl', $result );
+	}
+}

--- a/tests/e2e/admin-order.spec.ts
+++ b/tests/e2e/admin-order.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * E2E tests: Admin order management
+ *
+ * Verifies that delivery date/time data saved on checkout is visible in the
+ * WooCommerce admin order screen, and that the delivery date column appears
+ * in the order list.
+ */
+import { test, expect } from '@playwright/test';
+import {
+	login,
+	createProduct,
+	deleteProduct,
+	enablePaymentGateway,
+	setupFreeShippingZone,
+	deleteAllOrders,
+	setJp4wcSettings,
+	addProductToCart,
+	fillClassicCheckoutBilling,
+	placeClassicOrder,
+	wpFetch,
+	ADMIN_USER,
+	ADMIN_PASS,
+} from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+const BASIC_AUTH = (): string =>
+	Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD ?? ADMIN_PASS }` ).toString( 'base64' );
+
+/** Minimal Classic Checkout page content */
+const CLASSIC_CHECKOUT_CONTENT = `<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->`;
+
+let productId: number;
+let orderId: number;
+let classicCheckoutPageId: number;
+let classicCheckoutUrl: string;
+
+/** WC REST API helper */
+async function wcFetch(
+	request: import( '@playwright/test' ).APIRequestContext,
+	endpoint: string,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+	body?: object,
+) {
+	const res = await request.fetch( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
+		method,
+		headers: {
+			Authorization: `Basic ${ BASIC_AUTH() }`,
+			'Content-Type': 'application/json',
+		},
+		data: body ? JSON.stringify( body ) : undefined,
+	} );
+	return res.json();
+}
+
+test.beforeAll( async ( { request, browser } ) => {
+	await enablePaymentGateway( request, BASE_URL, 'cod' );
+	await setupFreeShippingZone( request, BASE_URL );
+	productId = await createProduct( request, BASE_URL );
+
+	// Create a Classic Checkout page for order placement.
+	const cp = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+		title: 'Classic Checkout (Orders Test)',
+		slug: 'classic-checkout-orders-test',
+		status: 'publish',
+		content: CLASSIC_CHECKOUT_CONTENT,
+	} ) as { id: number; link: string };
+	classicCheckoutPageId = cp.id;
+	classicCheckoutUrl    = cp.link;
+
+	// Enable delivery date (optional, not required).
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '1',
+		'delivery-date-required': '',
+	} );
+
+	// Place a test order with a delivery date selected.
+	const context = await browser.newContext();
+	const page    = await context.newPage();
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( classicCheckoutUrl );
+	await page.waitForLoadState( 'domcontentloaded' );
+	await page.selectOption( '#billing_country', 'JP' ).catch( () => {} );
+	await page.waitForLoadState( 'networkidle' ); // Wait for AJAX to update JP address fields.
+	await fillClassicCheckoutBilling( page );
+	await page.check( 'input[name="payment_method"][value="cod"]' );
+
+	// Pick the first available delivery date if the selector exists.
+	const dateSelect = page.locator( 'select[name="wc4jp_delivery_date"]' );
+	if ( await dateSelect.isVisible( { timeout: 3_000 } ).catch( () => false ) ) {
+		const options = await dateSelect.locator( 'option' ).all();
+		if ( options.length > 1 ) {
+			const firstValue = await options[ 1 ].getAttribute( 'value' );
+			if ( firstValue ) await dateSelect.selectOption( firstValue );
+		}
+	}
+
+	const orderUrl = await placeClassicOrder( page );
+
+	// Extract order ID from the Thank You URL.
+	const match = orderUrl.match( /order-received\/(\d+)/ );
+	if ( match ) {
+		orderId = parseInt( match[ 1 ], 10 );
+	}
+
+	await context.close();
+} );
+
+test.afterAll( async ( { request } ) => {
+	await deleteProduct( request, BASE_URL, productId );
+	await deleteAllOrders( request, BASE_URL );
+
+	if ( classicCheckoutPageId ) {
+		await wpFetch( request, BASE_URL, `pages/${ classicCheckoutPageId }?force=true`, 'DELETE' );
+	}
+
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '',
+		'delivery-date-required': '',
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Order list
+// ---------------------------------------------------------------------------
+
+test( 'admin order list shows the delivery date column', async ( { page } ) => {
+	await login( page, BASE_URL );
+
+	// WooCommerce HPOS order list.
+	await page.goto( `${ BASE_URL }/wp-admin/admin.php?page=wc-orders` );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	// Fallback to legacy post list if HPOS is not active.
+	const isHpos = await page.locator( '.wc-order-list-table-wrapper, .widefat.woocommerce-orders-table' )
+		.isVisible( { timeout: 3_000 } )
+		.catch( () => false );
+
+	if ( ! isHpos ) {
+		await page.goto( `${ BASE_URL }/wp-admin/edit.php?post_type=shop_order` );
+	}
+
+	// The delivery column header should be present (column key = wc4jp_delivery, label = "Delivery").
+	await expect(
+		page.locator( 'th:has-text("Delivery"), th:has-text("配送"), .column-wc4jp_delivery' ).first(),
+	).toBeVisible( { timeout: 10_000 } );
+} );
+
+// ---------------------------------------------------------------------------
+// Order detail
+// ---------------------------------------------------------------------------
+
+test( 'admin order edit page shows JP4WC delivery meta box', async ( { page } ) => {
+	await login( page, BASE_URL );
+
+	if ( ! orderId ) {
+		test.skip( true, 'No test order was created in beforeAll' );
+	}
+
+	// Navigate to order edit (HPOS).
+	await page.goto( `${ BASE_URL }/wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }` );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	// Fallback to legacy post edit.
+	if ( await page.locator( '#post-body' ).isVisible( { timeout: 2_000 } ).catch( () => false ) ) {
+		await page.goto( `${ BASE_URL }/wp-admin/post.php?post=${ orderId }&action=edit` );
+	}
+
+	// JP4WC adds a meta box with delivery date/time (id="jp4wc_shop_order").
+	await expect(
+		page.locator( '#jp4wc_shop_order, .jp4wc-order-meta, [id*="jp4wc"]' ).first(),
+	).toBeVisible( { timeout: 10_000 } );
+} );
+
+// ---------------------------------------------------------------------------
+// Order REST API: delivery meta saved
+// ---------------------------------------------------------------------------
+
+test( 'order meta contains delivery date after checkout', async ( { request } ) => {
+	if ( ! orderId ) {
+		test.skip( true, 'No test order was created in beforeAll' );
+	}
+
+	const order = await wcFetch( request, `orders/${ orderId }`, 'GET' ) as {
+		meta_data: { key: string; value: string }[];
+	};
+
+	const deliveryDateMeta = order.meta_data.find(
+		( m ) => m.key === 'wc4jp-delivery-date',
+	);
+
+	// The meta entry exists if the user selected a date during checkout.
+	// (It may be absent if the delivery date selector was not visible.)
+	if ( deliveryDateMeta ) {
+		expect( deliveryDateMeta.value ).toBeTruthy();
+	}
+} );

--- a/tests/e2e/admin-settings.spec.ts
+++ b/tests/e2e/admin-settings.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * E2E tests: JP4WC Admin Settings (React UI)
+ *
+ * Verifies that the settings page loads, toggles persist after save,
+ * and the REST API reflects the saved values.
+ */
+import { test, expect } from '@playwright/test';
+import { login, getJp4wcSettings, setJp4wcSettings } from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+test.beforeAll( async ( { request } ) => {
+	// Start from a known state: everything disabled.
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '',
+		'yomigana-required': '',
+		'delivery-date': '',
+		'delivery-date-required': '',
+		'delivery-time-zone': '',
+		'delivery-time-zone-required': '',
+	} );
+} );
+
+test.afterAll( async ( { request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '',
+		'yomigana-required': '',
+		'delivery-date': '',
+		'delivery-date-required': '',
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Page load
+// ---------------------------------------------------------------------------
+
+test( 'settings page loads without JS errors', async ( { page } ) => {
+	const jsErrors: string[] = [];
+	page.on( 'pageerror', ( err ) => jsErrors.push( err.message ) );
+
+	await login( page, BASE_URL );
+	await page.goto( `${ BASE_URL }/wp-admin/admin.php?page=jp4wc-settings` );
+
+	// React mounts into #jp4wc-admin-settings-root.
+	await expect( page.locator( '#jp4wc-admin-settings-root' ) )
+		.toBeVisible( { timeout: 15_000 } );
+
+	expect( jsErrors.filter( ( e ) => ! e.includes( 'deprecated' ) ) ).toHaveLength( 0 );
+} );
+
+// ---------------------------------------------------------------------------
+// Yomigana setting
+// ---------------------------------------------------------------------------
+
+test( 'enabling yomigana in admin persists after page reload', async ( { page, request } ) => {
+	await login( page, BASE_URL );
+	await page.goto( `${ BASE_URL }/wp-admin/admin.php?page=jp4wc-settings` );
+
+	// Wait for React to mount.
+	await page.locator( '#jp4wc-admin-settings-root' ).waitFor( { state: 'visible', timeout: 15_000 } );
+
+	// The yomigana setting uses ToggleControl with label "Name Yomigana".
+	// ToggleControl renders an input[type="checkbox"] inside the toggle wrapper.
+	const yomiganaToggle = page
+		.locator( '[class*="toggle-control"], [class*="checkbox-control"]' )
+		.filter( { hasText: /Name Yomigana/i } )
+		.locator( 'input[type="checkbox"]' )
+		.first();
+
+	await yomiganaToggle.waitFor( { state: 'attached', timeout: 15_000 } );
+	const wasChecked = await yomiganaToggle.isChecked();
+
+	if ( ! wasChecked ) {
+		await yomiganaToggle.click();
+	}
+
+	// Save the settings via the footer save button.
+	await page.locator( '.jp4wc-settings-footer button, button:has-text("Save Settings"), button:has-text("保存")' )
+		.first()
+		.click();
+	await page.waitForLoadState( 'networkidle' );
+
+	// Reload and verify the toggle is still on.
+	await page.goto( `${ BASE_URL }/wp-admin/admin.php?page=jp4wc-settings` );
+	await page.locator( '#jp4wc-admin-settings-root' ).waitFor( { state: 'visible', timeout: 15_000 } );
+	await yomiganaToggle.waitFor( { state: 'attached', timeout: 15_000 } );
+	await expect( yomiganaToggle ).toBeChecked();
+
+	// Also verify via REST API — keys are returned without wc4jp- prefix.
+	const settings = await getJp4wcSettings( request, BASE_URL );
+	expect( settings[ 'yomigana' ] ).toBeTruthy();
+} );
+
+// ---------------------------------------------------------------------------
+// Delivery date setting
+// ---------------------------------------------------------------------------
+
+test( 'REST API reflects delivery date setting saved from admin', async ( { request } ) => {
+	// Set via API first, then verify via API.
+	await setJp4wcSettings( request, BASE_URL, { 'delivery-date': '1' } );
+
+	const settings = await getJp4wcSettings( request, BASE_URL );
+	expect( settings[ 'delivery-date' ] ).toBeTruthy();
+
+	// Disable via API and verify.
+	await setJp4wcSettings( request, BASE_URL, { 'delivery-date': '' } );
+	const updated = await getJp4wcSettings( request, BASE_URL );
+	expect( updated[ 'delivery-date' ] ).toBeFalsy();
+} );
+
+// ---------------------------------------------------------------------------
+// Settings persistence via REST API round-trip
+// ---------------------------------------------------------------------------
+
+test( 'GET /jp4wc/v1/settings returns expected structure', async ( { request } ) => {
+	const settings = await getJp4wcSettings( request, BASE_URL );
+
+	// Must be an object with known JP4WC option keys (without wc4jp- prefix).
+	expect( typeof settings ).toBe( 'object' );
+	expect( settings ).toHaveProperty( 'yomigana' );
+	expect( settings ).toHaveProperty( 'delivery-date' );
+} );

--- a/tests/e2e/checkout-blocks.spec.ts
+++ b/tests/e2e/checkout-blocks.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * E2E tests: Block Checkout — yomigana and delivery fields
+ *
+ * Tests that yomigana fields appear correctly in the WooCommerce Checkout block,
+ * are positioned after the name fields (via CSS order), and show validation errors
+ * when required fields are empty.
+ *
+ * Prerequisite: a Checkout Block page must be accessible at /checkout-block-test/
+ * (created in beforeAll via the WP REST API).
+ */
+import { test, expect } from '@playwright/test';
+import {
+	createProduct,
+	deleteProduct,
+	enablePaymentGateway,
+	setupFreeShippingZone,
+	deleteAllOrders,
+	setJp4wcSettings,
+	addProductToCart,
+	wpFetch,
+} from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+let productId: number;
+let checkoutPageId: number;
+
+/** Minimal WooCommerce Checkout block page content */
+const CHECKOUT_BLOCK_CONTENT = `<!-- wp:woocommerce/checkout -->
+<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading">
+<!-- wp:woocommerce/checkout-fields-block -->
+<div class="wp-block-woocommerce-checkout-fields-block"></div>
+<!-- /wp:woocommerce/checkout-fields-block -->
+<!-- wp:woocommerce/checkout-totals-block -->
+<div class="wp-block-woocommerce-checkout-totals-block"></div>
+<!-- /wp:woocommerce/checkout-totals-block -->
+</div>
+<!-- /wp:woocommerce/checkout -->`;
+
+test.beforeAll( async ( { request } ) => {
+	await enablePaymentGateway( request, BASE_URL, 'cod' );
+	await setupFreeShippingZone( request, BASE_URL );
+	productId = await createProduct( request, BASE_URL );
+
+	// Create a test page with the Checkout block.
+	const page = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+		title: 'Block Checkout Test',
+		slug: 'checkout-block-test',
+		status: 'publish',
+		content: CHECKOUT_BLOCK_CONTENT,
+	} ) as { id: number };
+	checkoutPageId = page.id;
+} );
+
+test.afterAll( async ( { request } ) => {
+	await deleteProduct( request, BASE_URL, productId );
+	await deleteAllOrders( request, BASE_URL );
+
+	// Remove the test checkout page.
+	if ( checkoutPageId ) {
+		await wpFetch( request, BASE_URL, `pages/${ checkoutPageId }?force=true`, 'DELETE' );
+	}
+
+	// Restore yomigana settings.
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '',
+		'yomigana-required': '',
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Yomigana field visibility
+// ---------------------------------------------------------------------------
+
+test( 'yomigana fields are visible in Block Checkout when option is enabled', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '1',
+		'yomigana-required': '',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( `${ BASE_URL }/checkout-block-test/` );
+
+	await expect(
+		page.locator( 'input[id*="yomigana_last_name"], input[id*="yomigana_first_name"]' ).first(),
+	).toBeVisible( { timeout: 15_000 } );
+} );
+
+test( 'yomigana fields are NOT rendered when option is disabled', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '',
+		'yomigana-required': '',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( `${ BASE_URL }/checkout-block-test/` );
+	await page.waitForLoadState( 'networkidle' );
+
+	await expect(
+		page.locator( 'input[id*="yomigana_last_name"]' ),
+	).toHaveCount( 0 );
+} );
+
+// ---------------------------------------------------------------------------
+// Yomigana CSS order (field position)
+// ---------------------------------------------------------------------------
+
+test( 'yomigana fields appear after the name fields in the address form', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '1',
+		'yomigana-required': '',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( `${ BASE_URL }/checkout-block-test/` );
+
+	// Standard last-name field: WC Blocks uses id like "billing-last-name" or
+	// "shipping-last-name"; fall back to autocomplete attribute if needed.
+	const lastNameInput = page.locator(
+		'input[id*="last-name"]:not([id*="yomigana"]), input[id*="last_name"]:not([id*="yomigana"]), input[autocomplete*="family-name"]',
+	).first();
+	const yomiganaInput = page.locator( 'input[id*="yomigana_last_name"]' ).first();
+
+	await expect( lastNameInput ).toBeVisible( { timeout: 15_000 } );
+	await expect( yomiganaInput ).toBeVisible();
+
+	// Yomigana should appear below (higher Y position) than the name field.
+	const nameBox     = await lastNameInput.boundingBox();
+	const yomiganaBox = await yomiganaInput.boundingBox();
+
+	expect( nameBox ).not.toBeNull();
+	expect( yomiganaBox ).not.toBeNull();
+	expect( yomiganaBox!.y ).toBeGreaterThan( nameBox!.y );
+} );
+
+// ---------------------------------------------------------------------------
+// Yomigana validation (Block Checkout)
+// ---------------------------------------------------------------------------
+
+test( 'required yomigana shows validation error when submitted empty', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'yomigana': '1',
+		'yomigana-required': '1',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( `${ BASE_URL }/checkout-block-test/` );
+
+	// Wait for block checkout to render.
+	await page.waitForLoadState( 'networkidle' );
+
+	// Fill required standard fields but intentionally leave yomigana empty.
+	await page.locator( 'input[id*="last-name"]:not([id*="yomigana"]), input[id*="last_name"]:not([id*="yomigana"]), input[autocomplete*="family-name"]' )
+		.first().fill( '田中' ).catch( () => {} );
+	await page.locator( 'input[id*="first-name"]:not([id*="yomigana"]), input[id*="first_name"]:not([id*="yomigana"]), input[autocomplete*="given-name"]' )
+		.first().fill( '正平' ).catch( () => {} );
+	await page.locator( 'input[type="email"], input[autocomplete*="email"]' )
+		.first().fill( 'test@example.com' ).catch( () => {} );
+
+	// Attempt to place the order.
+	await page.locator(
+		'button[type="submit"].wc-block-components-checkout-place-order-button, ' +
+		'button.wc-block-checkout__submit-button, ' +
+		'button:has-text("Place Order"), button:has-text("注文する")',
+	).first().click( { timeout: 15_000 } ).catch( () => {} );
+
+	// Should show error (required yomigana not filled) and stay on checkout.
+	await expect( page ).not.toHaveURL( /order-received/, { timeout: 8_000 } );
+	await expect(
+		page.locator( '.wc-block-components-validation-error, [role="alert"], .wc-block-store-notice' ).first(),
+	).toBeVisible( { timeout: 10_000 } );
+} );

--- a/tests/e2e/checkout-classic.spec.ts
+++ b/tests/e2e/checkout-classic.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * E2E tests: Classic Checkout (shortcode) flow
+ *
+ * Covers the core bug regression (#166): after a successful payment,
+ * the browser must redirect to the Thank You page — not spin forever.
+ *
+ * Payment method: COD (no external credentials required)
+ */
+import { test, expect } from '@playwright/test';
+import {
+	createProduct,
+	deleteProduct,
+	enablePaymentGateway,
+	setupFreeShippingZone,
+	deleteAllOrders,
+	setJp4wcSettings,
+	addProductToCart,
+	fillClassicCheckoutBilling,
+	placeClassicOrder,
+	wpFetch,
+} from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+/** Minimal Classic Checkout page content */
+const CLASSIC_CHECKOUT_CONTENT = `<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->`;
+
+let productId: number;
+let classicCheckoutPageId: number;
+let classicCheckoutUrl: string;
+
+test.beforeAll( async ( { request } ) => {
+	await enablePaymentGateway( request, BASE_URL, 'cod' );
+	await setupFreeShippingZone( request, BASE_URL );
+	productId = await createProduct( request, BASE_URL );
+
+	// Create a test page with the Classic Checkout shortcode.
+	const page = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+		title: 'Classic Checkout Test',
+		slug: 'classic-checkout-test',
+		status: 'publish',
+		content: CLASSIC_CHECKOUT_CONTENT,
+	} ) as { id: number; link: string };
+	classicCheckoutPageId = page.id;
+	classicCheckoutUrl    = page.link;
+
+	// Ensure delivery date/time is disabled so it does not interfere.
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '',
+		'delivery-date-required': '',
+		'delivery-time-zone': '',
+		'delivery-time-zone-required': '',
+	} );
+} );
+
+test.afterAll( async ( { request } ) => {
+	await deleteProduct( request, BASE_URL, productId );
+	await deleteAllOrders( request, BASE_URL );
+
+	if ( classicCheckoutPageId ) {
+		await wpFetch( request, BASE_URL, `pages/${ classicCheckoutPageId }?force=true`, 'DELETE' );
+	}
+} );
+
+// ---------------------------------------------------------------------------
+// Bug regression: #166
+// ---------------------------------------------------------------------------
+
+test( 'COD payment redirects to Thank You page (regression #166)', async ( { page } ) => {
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( classicCheckoutUrl );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	await page.selectOption( '#billing_country', 'JP' ).catch( () => {} );
+	await page.waitForLoadState( 'networkidle' ); // Wait for AJAX to update JP address fields.
+	await fillClassicCheckoutBilling( page );
+	await page.check( 'input[name="payment_method"][value="cod"]' );
+
+	const orderUrl = await placeClassicOrder( page );
+
+	// placeClassicOrder already asserts redirect to order-received URL.
+	expect( orderUrl ).toMatch( /order-received/ );
+} );
+
+test( 'Thank You page shows order number', async ( { page } ) => {
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( classicCheckoutUrl );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	await page.selectOption( '#billing_country', 'JP' ).catch( () => {} );
+	await page.waitForLoadState( 'networkidle' );
+	await fillClassicCheckoutBilling( page );
+	await page.check( 'input[name="payment_method"][value="cod"]' );
+
+	await placeClassicOrder( page );
+
+	await expect(
+		page.locator( '.woocommerce-order-overview__order strong, .wc-bacs-bank-details-account-number' ).first(),
+	).toBeTruthy();
+} );
+
+// ---------------------------------------------------------------------------
+// Delivery date disabled — must not block checkout
+// ---------------------------------------------------------------------------
+
+test( 'checkout succeeds when delivery date option is disabled', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '',
+		'delivery-date-required': '1',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( classicCheckoutUrl );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	await page.selectOption( '#billing_country', 'JP' ).catch( () => {} );
+	await page.waitForLoadState( 'networkidle' );
+	await fillClassicCheckoutBilling( page );
+	await page.check( 'input[name="payment_method"][value="cod"]' );
+
+	// Even though required flag is set, the option is disabled → should pass.
+	const url = await placeClassicOrder( page );
+	expect( url ).toMatch( /order-received/ );
+} );
+
+// ---------------------------------------------------------------------------
+// Delivery date required — validation must block submission
+// ---------------------------------------------------------------------------
+
+test( 'checkout shows error when required delivery date is missing', async ( { page, request } ) => {
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '1',
+		'delivery-date-required': '1',
+	} );
+
+	await addProductToCart( page, BASE_URL, productId );
+	await page.goto( classicCheckoutUrl );
+	await page.waitForLoadState( 'domcontentloaded' );
+
+	await page.selectOption( '#billing_country', 'JP' ).catch( () => {} );
+	await page.waitForLoadState( 'networkidle' );
+	await fillClassicCheckoutBilling( page );
+	await page.check( 'input[name="payment_method"][value="cod"]' );
+
+	// Select the "unspecified" placeholder (value "0").
+	const dateSelect = page.locator( 'select[name="wc4jp_delivery_date"]' );
+	if ( await dateSelect.isVisible() ) {
+		await dateSelect.selectOption( '0' );
+	}
+
+	await page.click( '#place_order' );
+
+	// Should stay on checkout and show validation error.
+	await expect( page ).not.toHaveURL( /order-received/, { timeout: 8_000 } );
+	await expect(
+		page.locator( '.woocommerce-error, .woocommerce-NoticeGroup-checkout' ),
+	).toBeVisible();
+
+	// Restore setting.
+	await setJp4wcSettings( request, BASE_URL, {
+		'delivery-date': '',
+		'delivery-date-required': '',
+	} );
+} );

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,105 @@
+/**
+ * Playwright global setup
+ *
+ * Runs once before all e2e tests. Creates a WordPress Application Password
+ * for the admin user (via wp-env + WP-CLI) and stores it so all test files
+ * can authenticate against the REST API without browser-based login.
+ *
+ * Also performs initial WooCommerce configuration:
+ *  - Sets store country to Japan
+ *  - Enables COD payment gateway
+ *  - Creates a catch-all free-shipping zone
+ */
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const AUTH_DIR  = path.resolve( __dirname, '.auth' );
+const AUTH_FILE = path.join( AUTH_DIR, 'credentials.json' );
+
+export default async function globalSetup(): Promise<void> {
+	const baseURL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+	// Ensure .auth directory exists.
+	if ( ! fs.existsSync( AUTH_DIR ) ) {
+		fs.mkdirSync( AUTH_DIR, { recursive: true } );
+	}
+
+	// Generate (or reuse) Application Password via WP-CLI on the tests container.
+	let appPassword: string;
+	try {
+		const raw = execSync(
+			'npx wp-env run tests-cli wp user application-password create admin playwright-e2e --porcelain',
+			{ cwd: process.cwd(), encoding: 'utf8' },
+		).trim();
+		// wp-cli outputs only the password when --porcelain is set.
+		appPassword = raw.split( '\n' ).pop()!.trim();
+	} catch ( e ) {
+		throw new Error(
+			`Failed to create Application Password via WP-CLI.\n` +
+			`Make sure wp-env tests instance is running: npx wp-env start\n` +
+			String( e ),
+		);
+	}
+
+	// Persist credentials for test files.
+	fs.writeFileSync(
+		AUTH_FILE,
+		JSON.stringify( { user: 'admin', appPassword, baseURL } ),
+		'utf8',
+	);
+
+	// Make available to all tests in the same process.
+	process.env.WP_APP_PASSWORD = appPassword;
+	process.env.WP_BASE_URL     = baseURL;
+
+	// ---------------------------------------------------------------------------
+	// Initial WooCommerce setup via REST API
+	// ---------------------------------------------------------------------------
+	const auth = Buffer.from( `admin:${ appPassword }` ).toString( 'base64' );
+
+	const wcPut = async ( endpoint: string, body: object ) => {
+		const res = await fetch( `${ baseURL }/wp-json/wc/v3/${ endpoint }`, {
+			method: 'PUT',
+			headers: { Authorization: `Basic ${ auth }`, 'Content-Type': 'application/json' },
+			body: JSON.stringify( body ),
+		} );
+		if ( ! res.ok ) {
+			console.warn( `⚠ wcPut ${ endpoint } returned ${ res.status }` );
+		}
+	};
+
+	const wcPost = async ( endpoint: string, body: object ) => {
+		const res = await fetch( `${ baseURL }/wp-json/wc/v3/${ endpoint }`, {
+			method: 'POST',
+			headers: { Authorization: `Basic ${ auth }`, 'Content-Type': 'application/json' },
+			body: JSON.stringify( body ),
+		} );
+		return res.ok ? res.json() : null;
+	};
+
+	const wcGet = async ( endpoint: string ) => {
+		const res = await fetch( `${ baseURL }/wp-json/wc/v3/${ endpoint }`, {
+			headers: { Authorization: `Basic ${ auth }` },
+		} );
+		return res.ok ? res.json() : [];
+	};
+
+	// Set store country to Japan.
+	await wcPut( 'settings/general/woocommerce_default_country', { value: 'JP' } );
+
+	// Enable COD payment.
+	await wcPut( 'payment_gateways/cod', { enabled: true } );
+
+	// Create free-shipping zone for Japan if not already present.
+	const zones = ( await wcGet( 'shipping/zones' ) ) as { id: number; name: string }[];
+	const exists = zones.some( ( z ) => z.name === 'Japan (e2e)' );
+	if ( ! exists ) {
+		const zone = ( await wcPost( 'shipping/zones', { name: 'Japan (e2e)' } ) ) as { id: number } | null;
+		if ( zone ) {
+			await wcPost( `shipping/zones/${ zone.id }/methods`, { method_id: 'free_shipping' } );
+		}
+	}
+
+	console.log( '✔ E2E global setup complete.' );
+}

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -1,0 +1,238 @@
+import { type Page, type APIRequestContext, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// ---------------------------------------------------------------------------
+// WP REST API helper
+// ---------------------------------------------------------------------------
+
+/** WP REST API helper for /wp-json/wp/v2/ endpoints */
+export async function wpFetch(
+	request: APIRequestContext,
+	baseURL: string,
+	endpoint: string,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+	body?: object,
+) {
+	const res = await request.fetch( `${ baseURL }/wp-json/wp/v2/${ endpoint }`, {
+		method,
+		headers: {
+			Authorization: `Basic ${ getBasicAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: body ? JSON.stringify( body ) : undefined,
+	} );
+	return res.json();
+}
+
+/** wp-env default admin user (password is used only for WP login form) */
+export const ADMIN_USER = 'admin';
+export const ADMIN_PASS = 'password';
+
+/** Read the Application Password written by global-setup.ts */
+function getBasicAuth(): string {
+	// Prefer env var (set by global-setup in the same process).
+	if ( process.env.WP_APP_PASSWORD ) {
+		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
+	}
+	// Fallback: read from credentials file.
+	const credFile = path.resolve( __dirname, '../.auth/credentials.json' );
+	if ( fs.existsSync( credFile ) ) {
+		const creds = JSON.parse( fs.readFileSync( credFile, 'utf8' ) ) as { user: string; appPassword: string };
+		return Buffer.from( `${ creds.user }:${ creds.appPassword }` ).toString( 'base64' );
+	}
+	// Last resort: plain password (works only if Application Passwords are not enforced).
+	return Buffer.from( `${ ADMIN_USER }:${ ADMIN_PASS }` ).toString( 'base64' );
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/** Log in to WordPress wp-admin. */
+export async function login( page: Page, baseURL: string ): Promise<void> {
+	await page.goto( `${ baseURL }/wp-login.php` );
+	await page.fill( '#user_login', ADMIN_USER );
+	await page.fill( '#user_pass', ADMIN_PASS );
+	await page.click( '#wp-submit' );
+	await page.waitForURL( /wp-admin/ );
+}
+
+// ---------------------------------------------------------------------------
+// WooCommerce REST API helpers
+// ---------------------------------------------------------------------------
+
+async function wcFetch(
+	request: APIRequestContext,
+	baseURL: string,
+	endpoint: string,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+	body?: object,
+) {
+	const url = `${ baseURL }/wp-json/wc/v3/${ endpoint }`;
+	const opts: Parameters< typeof request.fetch >[ 1 ] = {
+		method,
+		headers: {
+			Authorization: `Basic ${ getBasicAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: body ? JSON.stringify( body ) : undefined,
+	};
+	const res = await request.fetch( url, opts );
+	return res.json();
+}
+
+/** Create a simple physical product. Returns the new product ID. */
+export async function createProduct(
+	request: APIRequestContext,
+	baseURL: string,
+	opts: { name?: string; price?: string; virtual?: boolean } = {},
+): Promise<number> {
+	const data = await wcFetch( request, baseURL, 'products', 'POST', {
+		name: opts.name ?? 'Test Product',
+		type: 'simple',
+		regular_price: opts.price ?? '1000',
+		virtual: opts.virtual ?? false,
+		manage_stock: false,
+		stock_status: 'instock',
+	} );
+	return data.id as number;
+}
+
+/** Delete a product by ID. */
+export async function deleteProduct(
+	request: APIRequestContext,
+	baseURL: string,
+	productId: number,
+): Promise<void> {
+	await wcFetch( request, baseURL, `products/${ productId }?force=true`, 'DELETE' );
+}
+
+/** Enable a payment gateway (e.g. 'cod', 'cheque'). */
+export async function enablePaymentGateway(
+	request: APIRequestContext,
+	baseURL: string,
+	gatewayId: string,
+): Promise<void> {
+	await wcFetch( request, baseURL, `payment_gateways/${ gatewayId }`, 'PUT', {
+		enabled: true,
+	} );
+}
+
+/** Set up a catch-all flat-rate shipping zone (¥0 fee). */
+export async function setupFreeShippingZone(
+	request: APIRequestContext,
+	baseURL: string,
+): Promise<void> {
+	// Check if "Everywhere" zone already has a free-shipping method.
+	const zones = ( await wcFetch( request, baseURL, 'shipping/zones', 'GET' ) ) as { id: number; name: string }[];
+	const everywhere = zones.find( ( z ) => z.name === 'Locations not covered by your other zones' );
+	if ( everywhere ) {
+		const methods = ( await wcFetch(
+			request, baseURL, `shipping/zones/${ everywhere.id }/methods`, 'GET',
+		) ) as { method_id: string }[];
+		if ( methods.some( ( m ) => m.method_id === 'free_shipping' ) ) return;
+	}
+
+	// Create a new zone covering Japan and add free shipping.
+	const zone = ( await wcFetch( request, baseURL, 'shipping/zones', 'POST', {
+		name: 'Japan (test)',
+	} ) ) as { id: number };
+
+	await wcFetch( request, baseURL, `shipping/zones/${ zone.id }/methods`, 'POST', {
+		method_id: 'free_shipping',
+	} );
+}
+
+/** Delete all orders (for cleanup). */
+export async function deleteAllOrders(
+	request: APIRequestContext,
+	baseURL: string,
+): Promise<void> {
+	const orders = ( await wcFetch( request, baseURL, 'orders?per_page=50', 'GET' ) ) as { id: number }[];
+	await Promise.all(
+		orders.map( ( o ) => wcFetch( request, baseURL, `orders/${ o.id }?force=true`, 'DELETE' ) ),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// JP4WC settings via custom REST endpoint
+// ---------------------------------------------------------------------------
+
+/** Read JP4WC settings from /jp4wc/v1/settings. */
+export async function getJp4wcSettings(
+	request: APIRequestContext,
+	baseURL: string,
+): Promise<Record<string, unknown>> {
+	const res = await request.fetch( `${ baseURL }/wp-json/jp4wc/v1/settings`, {
+		headers: { Authorization: `Basic ${ getBasicAuth() }` },
+	} );
+	return res.json();
+}
+
+/** Write JP4WC settings to /jp4wc/v1/settings. */
+export async function setJp4wcSettings(
+	request: APIRequestContext,
+	baseURL: string,
+	settings: Record<string, unknown>,
+): Promise<void> {
+	await request.fetch( `${ baseURL }/wp-json/jp4wc/v1/settings`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${ getBasicAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: JSON.stringify( settings ),
+	} );
+}
+
+// ---------------------------------------------------------------------------
+// Browser / page helpers
+// ---------------------------------------------------------------------------
+
+/** Add a product to cart by visiting its shop URL. */
+export async function addProductToCart(
+	page: Page,
+	baseURL: string,
+	productId: number,
+): Promise<void> {
+	await page.goto( `${ baseURL }/?add-to-cart=${ productId }` );
+	// Wait until the cart widget reflects the addition.
+	await page.waitForLoadState( 'networkidle' );
+}
+
+/**
+ * Fill WooCommerce Classic Checkout billing fields.
+ * All fields use Japanese test data appropriate for the JP4WC plugin.
+ * Call after selecting billing_country='JP' and waiting for network idle.
+ */
+export async function fillClassicCheckoutBilling(
+	page: Page,
+	opts: {
+		firstName?: string;
+		lastName?: string;
+		state?: string;
+		address?: string;
+		city?: string;
+		postcode?: string;
+		phone?: string;
+		email?: string;
+	} = {},
+): Promise<void> {
+	await page.fill( '#billing_last_name', opts.lastName ?? '田中' );
+	await page.fill( '#billing_first_name', opts.firstName ?? '正平' );
+	// Select JP prefecture (state). Default: 東京都 = JP13.
+	await page.selectOption( '#billing_state', opts.state ?? 'JP13' ).catch( () => {} );
+	await page.fill( '#billing_postcode', opts.postcode ?? '150-0001' );
+	await page.fill( '#billing_address_1', opts.address ?? '渋谷1-1-1' );
+	await page.fill( '#billing_city', opts.city ?? '渋谷区' );
+	await page.fill( '#billing_phone', opts.phone ?? '0312345678' );
+	await page.fill( '#billing_email', opts.email ?? 'test-e2e@example.com' );
+}
+
+/** Place the Classic Checkout order and return the received-order URL. */
+export async function placeClassicOrder( page: Page ): Promise<string> {
+	await page.click( '#place_order' );
+	await expect( page ).toHaveURL( /order-received/, { timeout: 20_000 } );
+	return page.url();
+}

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "commonjs",
+		"lib": [ "ES2020", "DOM" ],
+		"types": [ "node", "@playwright/test" ],
+		"strict": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"outDir": "./tests/e2e/.compiled"
+	},
+	"include": [ "tests/e2e/**/*.ts", "playwright.config.ts" ],
+	"exclude": [ "node_modules" ]
+}


### PR DESCRIPTION
## 概要

Classic Checkout（ショートコード）環境でSquare・Amazon Pay決済後にブラウザがThank Youページへ遷移しない問題を修正。決済は成功するが AJAX レスポンスが破損し、ユーザーが再注文することで二重注文が多発していた。

Closes #166

## 変更内容

- `includes/class-jp4wc-delivery.php`
  - `woocommerce_payment_successful_result` フィルターの引数数を `1` → `2` に修正
  - `jp4wc_delivery_check_data` の関数シグネチャに `$order_id` を追加（第2引数として受け取る）
  - `wc_get_order()` が `false` を返した場合の早期リターンガードを追加

- `includes/blocks/class-jp4wc-delivery-blocks-integration.php`
  - "NOT registered" ログを `log_info` → `log_debug`（`WP_DEBUG` 時のみ出力）に変更し、1日2MBのログ大量生成を解消
  - `log_debug` メソッドを追加

## 修正内容の詳細

```php
// Before（バグあり）
add_filter( 'woocommerce_payment_successful_result', array( $this, 'jp4wc_delivery_check_data' ), 10, 1 );

public function jp4wc_delivery_check_data( $result ) {
    $order_id = $result['order_id']; // Square/Amazon Payの戻り値には order_id が存在しない
    $order    = wc_get_order( $order_id ); // → wc_get_order(null) → false
    $date     = $order->get_meta( ... );   // → Fatal Error!
}

// After（修正済み）
add_filter( 'woocommerce_payment_successful_result', array( $this, 'jp4wc_delivery_check_data' ), 10, 2 );

public function jp4wc_delivery_check_data( $result, $order_id ) {
    $order = wc_get_order( $order_id );
    if ( ! $order ) {
        return $result;
    }
    // ...
}
```

## テスト項目

- [ ] Classic Checkout で Square 決済 → Thank You ページに正常遷移すること
- [ ] Classic Checkout で Amazon Pay 決済 → Thank You ページに正常遷移すること
- [ ] 配送日時必須設定あり・未入力 → 決済失敗・管理者メール通知が動作すること
- [ ] Block Checkout での配送日時フィールド表示・保存が正常であること
- [ ] WP_DEBUG=false 環境で "NOT registered" ログが出力されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)