### PR TITLE
Fix {last_name} {first_name} placeholder shown verbatim in Checkout Block UI

### DIFF
--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -194,6 +194,13 @@ class JP4WC_Address_Fields {
 			$fields['{last_name}'] = $args['last_name'];
 		}
 
+		// Apply honorific suffix here (PHP-only): WooCommerce Blocks JS replaces format
+		// placeholders client-side and never calls this filter, so 様 is kept out of the
+		// format string itself (see address_formats()).
+		if ( get_option( 'wc4jp-honorific-suffix' ) && isset( $fields['{first_name}'] ) ) {
+			$fields['{first_name}'] .= '様';
+		}
+
 		if ( get_option( 'wc4jp-yomigana' ) ) {
 			$fields['{yomigana_last_name}']  = isset( $args['yomigana_last_name'] ) ? $args['yomigana_last_name'] : '';
 			$fields['{yomigana_first_name}'] = isset( $args['yomigana_first_name'] ) ? $args['yomigana_first_name'] : '';
@@ -216,13 +223,7 @@ class JP4WC_Address_Fields {
 	public function address_formats( $fields ) {
 		$include_yomigana = get_option( 'wc4jp-yomigana' );
 
-		$country_format = $this->show_country_in_address() ? "\n {country}" : '';
-
-		// honorific suffix.
-		$honorific_suffix = '';
-		if ( get_option( 'wc4jp-honorific-suffix' ) ) {
-			$honorific_suffix = '様';
-		}
+		$country_inner = $this->show_country_in_address() ? '{country}' : '';
 
 		// PayPal Payment compatible.
 		if ( isset( $_GET['woo-paypal-return'] ) && true === $_GET['woo-paypal-return'] && isset( $_GET['token'] ) ) {// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -232,10 +233,15 @@ class JP4WC_Address_Fields {
 		}
 
 		// Build format string based on settings.
+		// {last_name} {first_name} must be followed immediately by \n: WooCommerce Blocks JS
+		// (checkout-frontend.js) identifies the name line by searching for this pattern and
+		// removes it before rendering the address portion. Without the trailing \n the name
+		// placeholders are never substituted and appear verbatim in the Checkout Block UI.
+		// Honorific suffix (様) is applied in address_replacements() for PHP-only contexts.
 		if ( get_option( 'wc4jp-company-name' ) ) {
-			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}\n{company}" . $set_yomigana . "\n{last_name} {first_name}" . $honorific_suffix . $country_format;
+			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}\n{company}" . $set_yomigana . "\n{last_name} {first_name}\n" . $country_inner;
 		} else {
-			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}" . $set_yomigana . "\n{last_name} {first_name}" . $honorific_suffix . $country_format;
+			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}" . $set_yomigana . "\n{last_name} {first_name}\n" . $country_inner;
 		}
 
 		if ( is_cart() ) {

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -197,7 +197,7 @@ class JP4WC_Address_Fields {
 		// Apply honorific suffix here (PHP-only): WooCommerce Blocks JS replaces format
 		// placeholders client-side and never calls this filter, so 様 is kept out of the
 		// format string itself (see address_formats()).
-		if ( get_option( 'wc4jp-honorific-suffix' ) && isset( $fields['{first_name}'] ) ) {
+		if ( get_option( 'wc4jp-honorific-suffix' ) && isset( $fields['{first_name}'] ) && isset( $args['country'] ) && 'JP' === $args['country'] ) {
 			$fields['{first_name}'] .= '様';
 		}
 


### PR DESCRIPTION
## Summary

- WooCommerce 10.7.0 環境でブロックチェックアウトに `{last_name} {first_name}` がそのまま表示される問題を修正
- 根本原因: WooCommerce Blocks JS（`checkout-frontend.js`）はフォーマット文字列から `{last_name} {first_name}\n` パターンを検索して名前部分を分離するが、honorific suffix（様）または末尾位置のため `\n` がなくパターン検出が失敗していた

## Root Cause

`src/Blocks/BlockTypes/Checkout.php` の `enqueue_data()` が `get_address_formats()` 結果を `countryData[JP]['format']` として JS に渡す。JS はフォーマット文字列を名前（`c` テーブル）と住所（`r` テーブル）に分けて client-side で処理するが、名前パターン検出は `{last_name} {first_name}\n` 形式にのみ対応している。

旧フォーマット: `...\n{last_name} {first_name}様` → `\n` がないため JS が検出失敗 → プレースホルダーがそのまま表示

## Fix

- `address_formats()`: `{last_name} {first_name}` の直後に `\n` を必ず付加。honorific suffix（様）をフォーマット文字列から除去。
- `address_replacements()`: `wc4jp-honorific-suffix` 有効時に `{first_name}` へ `様` を付加。PHP レンダリングコンテキスト（注文メール・注文完了ページ・マイアカウント）では引き続き `様` が表示される。

## Test plan

- [ ] ブロックチェックアウトで `{last_name} {first_name}` が表示されないことを確認
- [ ] 注文完了メールに `様` が正しく表示されること（honorific suffix 有効時）
- [ ] 注文完了ページ・マイアカウントのアドレス表示に `様` が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)