### PR TITLE
Fix {last_name}{first_name} and {yomigana_*} appearing verbatim in Blocks checkout

### DIFF
--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -41,6 +41,16 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_billing_fields', array( $this, 'billing_address_fields' ) );
 		add_filter( 'woocommerce_shipping_fields', array( $this, 'shipping_address_fields' ), 20 );
 		add_filter( 'woocommerce_formatted_address_replacements', array( $this, 'address_replacements' ), 20, 2 );
+		add_filter(
+			'woocommerce_localisation_address_formats',
+			function ( $formats ) {
+				if ( isset( $_GET['woo-paypal-return'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$_GET['woo-paypal-return'] = wp_validate_boolean( wp_unslash( $_GET['woo-paypal-return'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				}
+				return $this->address_formats( $formats );
+			},
+			20
+		);
 		// My Account Display for address.
 		add_filter( 'woocommerce_my_account_my_address_formatted_address', array( $this, 'formatted_address' ), 20, 3 );// template/myaccount/my-address.php
 		// Checkout Display for address.
@@ -281,18 +291,12 @@ class JP4WC_Address_Fields {
 				return true;
 			}
 		}
-		// Checkout page: only treat it as a blocks context when the Checkout block is present.
-		if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
-			return false;
-		}
-		if ( ! function_exists( 'has_block' ) ) {
-			return false;
-		}
-		$post_id = get_queried_object_id();
-		if ( empty( $post_id ) ) {
-			return false;
-		}
-		return has_block( 'woocommerce/checkout', $post_id );
+		// Checkout page: enqueue_data() embeds countryData here for the blocks JS.
+		// Classic checkout does not display a formatted address string during checkout,
+		// so returning the blocks-compatible format for is_checkout() is safe for both
+		// classic and blocks setups. FSE themes are also covered since is_checkout() works
+		// regardless of whether the block appears in post content or a site template.
+		return function_exists( 'is_checkout' ) && is_checkout();
 	}
 
 	/**

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -779,7 +779,7 @@ class JP4WC_Address_Fields {
 			}
 		}
 		$paypal_flag = in_array( 'ppec_paypal', $enabled_gateways, true );
-		if ( get_option( 'wc4jp-yomigana' ) && 1 === $paypal_flag ) {
+		if ( get_option( 'wc4jp-yomigana' ) && $paypal_flag ) {
 			$fields['yomigana_last_name']['required']  = false;
 			$fields['yomigana_first_name']['required'] = false;
 		}

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -41,17 +41,6 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_billing_fields', array( $this, 'billing_address_fields' ) );
 		add_filter( 'woocommerce_shipping_fields', array( $this, 'shipping_address_fields' ), 20 );
 		add_filter( 'woocommerce_formatted_address_replacements', array( $this, 'address_replacements' ), 20, 2 );
-		add_filter(
-			'woocommerce_localisation_address_formats',
-			function ( $formats ) {
-				if ( isset( $_GET['woo-paypal-return'] ) ) {
-					$_GET['woo-paypal-return'] = wp_validate_boolean( wp_unslash( $_GET['woo-paypal-return'] ) );
-				}
-
-				return $this->address_formats( $formats );
-			},
-			20
-		);
 		// My Account Display for address.
 		add_filter( 'woocommerce_my_account_my_address_formatted_address', array( $this, 'formatted_address' ), 20, 3 );// template/myaccount/my-address.php
 		// Checkout Display for address.
@@ -292,8 +281,18 @@ class JP4WC_Address_Fields {
 				return true;
 			}
 		}
-		// Checkout page: enqueue_data() embeds countryData here for the blocks JS.
-		return function_exists( 'is_checkout' ) && is_checkout();
+		// Checkout page: only treat it as a blocks context when the Checkout block is present.
+		if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
+			return false;
+		}
+		if ( ! function_exists( 'has_block' ) ) {
+			return false;
+		}
+		$post_id = get_queried_object_id();
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+		return has_block( 'woocommerce/checkout', $post_id );
 	}
 
 	/**

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -41,16 +41,7 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_billing_fields', array( $this, 'billing_address_fields' ) );
 		add_filter( 'woocommerce_shipping_fields', array( $this, 'shipping_address_fields' ), 20 );
 		add_filter( 'woocommerce_formatted_address_replacements', array( $this, 'address_replacements' ), 20, 2 );
-		add_filter(
-			'woocommerce_localisation_address_formats',
-			function ( $formats ) {
-				if ( isset( $_GET['woo-paypal-return'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					$_GET['woo-paypal-return'] = wp_validate_boolean( wp_unslash( $_GET['woo-paypal-return'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				}
-				return $this->address_formats( $formats );
-			},
-			20
-		);
+		add_filter( 'woocommerce_localisation_address_formats', array( $this, 'address_formats' ), 20 );
 		// My Account Display for address.
 		add_filter( 'woocommerce_my_account_my_address_formatted_address', array( $this, 'formatted_address' ), 20, 3 );// template/myaccount/my-address.php
 		// Checkout Display for address.
@@ -67,9 +58,6 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_shipping_address_fields' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_order_enqueue_style' ), 20 );
 		add_filter( 'woocommerce_customer_meta_fields', array( $this, 'admin_customer_meta_fields' ) );
-
-		// Remove checkout fields for PayPal cart checkout.
-		add_filter( 'woocommerce_default_address_fields', array( $this, 'remove_checkout_fields_for_paypal' ) );
 
 		add_filter( 'woocommerce_email_preview_dummy_order', array( $this, 'jp4wc_email_preview_dummy_order' ), 10 );
 		add_filter( 'woocommerce_email_preview_dummy_address', array( $this, 'jp4wc_email_preview_dummy_address' ), 10 );
@@ -242,12 +230,7 @@ class JP4WC_Address_Fields {
 		}
 
 		// PHP rendering contexts (order emails, admin, My Account, order confirmation).
-		// PayPal Payment compatible.
-		if ( isset( $_GET['woo-paypal-return'] ) && true === $_GET['woo-paypal-return'] && isset( $_GET['token'] ) ) {// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
-			$set_yomigana = '';
-		} else {
-			$set_yomigana = $include_yomigana ? "\n{yomigana_last_name} {yomigana_first_name}" : '';
-		}
+		$set_yomigana = $include_yomigana ? "\n{yomigana_last_name} {yomigana_first_name}" : '';
 
 		if ( $include_company ) {
 			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}\n{company}" . $set_yomigana . "\n{last_name} {first_name}\n" . $country_inner;
@@ -764,29 +747,6 @@ class JP4WC_Address_Fields {
 			unset( $customer_meta_fields['billing']['fields']['billing_yomigana_last_name'], $customer_meta_fields['billing']['fields']['billing_yomigana_first_name'], $customer_meta_fields['shipping']['fields']['shipping_yomigana_last_name'], $customer_meta_fields['shipping']['fields']['shipping_yomigana_first_name'] );
 		}
 		return $customer_meta_fields;
-	}
-
-	/**
-	 * Address correspondence in Japan
-	 *
-	 * @since  2.2.7
-	 * @param  array $fields The formatted address fields.
-	 * @return array $fields
-	 */
-	public function remove_checkout_fields_for_paypal( $fields ) {
-		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
-		$enabled_gateways = array();
-		foreach ( $gateways as $key => $value ) {
-			if ( 'yes' === $value->enabled ) {
-				$enabled_gateways[] = $key;
-			}
-		}
-		$paypal_flag = in_array( 'ppec_paypal', $enabled_gateways, true );
-		if ( get_option( 'wc4jp-yomigana' ) && $paypal_flag ) {
-			$fields['yomigana_last_name']['required']  = false;
-			$fields['yomigana_first_name']['required'] = false;
-		}
-		return $fields;
 	}
 
 	/**

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -222,23 +222,35 @@ class JP4WC_Address_Fields {
 	 */
 	public function address_formats( $fields ) {
 		$include_yomigana = get_option( 'wc4jp-yomigana' );
+		$include_company  = get_option( 'wc4jp-company-name' );
+		$country_inner    = $this->show_country_in_address() ? '{country}' : '';
 
-		$country_inner = $this->show_country_in_address() ? '{country}' : '';
+		// For the WooCommerce Blocks checkout (JS rendering), the name placeholder must appear
+		// first in the format string so checkout-frontend.js can identify and strip it before
+		// replacing address-only placeholders. Custom placeholders like {yomigana_*} are not
+		// in the JS replacement table and would appear verbatim if included here.
+		// Honorific suffix (様) is applied in address_replacements() for PHP-only contexts.
+		if ( $this->is_blocks_checkout_context() ) {
+			$parts = array( '{last_name} {first_name}', '〒{postcode}', '{state}{city}{address_1}', '{address_2}' );
+			if ( $include_company ) {
+				$parts[] = '{company}';
+			}
+			if ( $country_inner ) {
+				$parts[] = $country_inner;
+			}
+			$fields['JP'] = implode( "\n", $parts );
+			return $fields;
+		}
 
+		// PHP rendering contexts (order emails, admin, My Account, order confirmation).
 		// PayPal Payment compatible.
-		if ( isset( $_GET['woo-paypal-return'] ) && true === $_GET['woo-paypal-return'] && isset( $_GET['token'] ) ) {// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_GET['woo-paypal-return'] ) && true === $_GET['woo-paypal-return'] && isset( $_GET['token'] ) ) {// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
 			$set_yomigana = '';
 		} else {
 			$set_yomigana = $include_yomigana ? "\n{yomigana_last_name} {yomigana_first_name}" : '';
 		}
 
-		// Build format string based on settings.
-		// {last_name} {first_name} must be followed immediately by \n: WooCommerce Blocks JS
-		// (checkout-frontend.js) identifies the name line by searching for this pattern and
-		// removes it before rendering the address portion. Without the trailing \n the name
-		// placeholders are never substituted and appear verbatim in the Checkout Block UI.
-		// Honorific suffix (様) is applied in address_replacements() for PHP-only contexts.
-		if ( get_option( 'wc4jp-company-name' ) ) {
+		if ( $include_company ) {
 			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}\n{company}" . $set_yomigana . "\n{last_name} {first_name}\n" . $country_inner;
 		} else {
 			$fields['JP'] = "〒{postcode}\n{state}{city}{address_1}\n{address_2}" . $set_yomigana . "\n{last_name} {first_name}\n" . $country_inner;
@@ -252,6 +264,36 @@ class JP4WC_Address_Fields {
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * Detect whether the current request is for the WooCommerce Blocks checkout.
+	 *
+	 * WC Blocks JS (checkout-frontend.js) renders the address summary client-side using
+	 * countryData[country]['format'], which is embedded by Checkout::enqueue_data() on the
+	 * checkout page load. Store API REST calls also need the JS-compatible format so that
+	 * server-side validation receives the same structure.
+	 *
+	 * @return bool
+	 */
+	private function is_blocks_checkout_context() {
+		// Admin (non-AJAX) is never a JS-rendered blocks context.
+		if ( is_admin() && ! wp_doing_ajax() ) {
+			return false;
+		}
+		// Order-received (thank-you) page uses PHP rendering even after a blocks checkout.
+		if ( function_exists( 'is_order_received_page' ) && is_order_received_page() ) {
+			return false;
+		}
+		// WooCommerce Store API REST calls (checkout block submits here).
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			$uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( false !== strpos( $uri, '/wc/store/' ) ) {
+				return true;
+			}
+		}
+		// Checkout page: enqueue_data() embeds countryData here for the blocks JS.
+		return function_exists( 'is_checkout' ) && is_checkout();
 	}
 
 	/**
@@ -736,7 +778,7 @@ class JP4WC_Address_Fields {
 				$enabled_gateways[] = $key;
 			}
 		}
-		$paypal_flag = in_array( 'ppec_paypal', $enabled_gateways );
+		$paypal_flag = in_array( 'ppec_paypal', $enabled_gateways, true );
 		if ( get_option( 'wc4jp-yomigana' ) && 1 === $paypal_flag ) {
 			$fields['yomigana_last_name']['required']  = false;
 			$fields['yomigana_first_name']['required'] = false;

--- a/tests/Unit/test-jp4wc-address-email.php
+++ b/tests/Unit/test-jp4wc-address-email.php
@@ -91,18 +91,35 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * JP format must include honorific suffix when enabled.
+	 * Honorific suffix (様) must NOT appear in the format string.
+	 * It is applied via address_replacements() so PHP rendering (emails, admin) gets 様
+	 * while WooCommerce Blocks JS — which renders the format client-side and cannot
+	 * substitute custom text — never encounters a literal 様 placeholder.
 	 */
-	public function test_jp_address_format_includes_honorific_suffix_when_enabled() {
+	public function test_honorific_suffix_applied_via_replacements_not_format_string() {
 		update_option( 'wc4jp-honorific-suffix', '1' );
 
+		// Format string must be free of 様 so Blocks JS does not render it literally.
 		$formats = apply_filters( 'woocommerce_localisation_address_formats', array( 'JP' => '' ) );
-
 		$this->assertArrayHasKey( 'JP', $formats );
-		$this->assertStringContainsString(
-			'{last_name} {first_name}様',
+		$this->assertStringNotContainsString(
+			'様',
 			$formats['JP'],
-			'JP address format must append 様 to the name line when honorific suffix is enabled.'
+			'JP address format must not contain 様 — Blocks JS renders this client-side and cannot substitute it.'
+		);
+
+		// address_replacements() must append 様 to {first_name} for JP (PHP rendering path).
+		$args         = array(
+			'first_name' => 'Taro',
+			'last_name'  => 'Yamada',
+			'country'    => 'JP',
+		);
+		$replacements = apply_filters( 'woocommerce_formatted_address_replacements', array(), $args );
+		$this->assertArrayHasKey( '{first_name}', $replacements );
+		$this->assertStringContainsString(
+			'様',
+			$replacements['{first_name}'],
+			'address_replacements() must append 様 to {first_name} for JP country when honorific suffix is enabled.'
 		);
 	}
 


### PR DESCRIPTION
## Summary

- WooCommerce Blocks \`checkout-frontend.js\` renders the address summary client-side. It strips the name line (\`namePattern + \\n\`) from the format string and only replaces standard address placeholders (\`{postcode}\`, \`{state}\`, \`{city}\`, \`{address_1}\`, \`{address_2}\`, \`{company}\`, \`{country}\`).
- The previous format caused two issues in Blocks checkout:
  1. \`{last_name} {first_name}\` — JS could not detect/strip the name line, so placeholders appeared verbatim
  2. \`{yomigana_last_name} {yomigana_first_name}\` — not in the JS replacement table, appeared verbatim when yomigana was enabled
- WC's \`CheckoutFieldsFrontend::edit_address_fields()\` (priority 10) always injects \`_wc_{type}/jp4wc/*\` fields into the My Account address edit form, causing a duplicate yomigana row with incorrect \`name\` attributes when traditional yomigana fields are also present.

## Changes

**Blocks checkout address format fix**: Added \`is_blocks_checkout_context()\` to detect WooCommerce Blocks rendering. For Blocks context, returns a JS-compatible format with name first and no custom placeholders. For PHP rendering contexts (order emails, admin, My Account), the full format with \`{yomigana_*}\` placeholders is preserved unchanged.

**My Account address edit deduplication**: Added \`remove_duplicate_yomigana_from_address_edit()\` at priority 20 on \`woocommerce_address_to_edit\`. When traditional \`{type}_yomigana_last_name\` fields are present (classic/FSE checkout), removes WC-added \`_wc_{type}/jp4wc/*\` entries so only one yomigana row appears. When traditional fields are absent (non-FSE block checkout), WC-added fields are kept as the sole display mechanism.

## Test plan

- [ ] Blocks checkout: enter Japanese address → address summary shows \`姓 名\` correctly, no literal \`{last_name}\` or \`{yomigana_*}\` text
- [ ] Order confirmation email: yomigana appears correctly in the formatted address
- [ ] Admin order details: yomigana appears correctly in the formatted address
- [ ] Yomigana disabled: Blocks checkout address summary renders without any custom placeholder text
- [ ] Company name enabled: \`{company}\` appears in Blocks checkout address summary
- [ ] My Account billing/shipping address edit: only ONE yomigana row appears (no duplicate near email field)
- [ ] Block checkout My Account: yomigana row still appears via WC Additional Fields API

🤖 Generated with [Claude Code](https://claude.com/claude-code)