### PR TITLE
Fix duplicate yomigana rows in My Account address edit form

### DIFF
--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -65,8 +65,8 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_email_preview_dummy_product_variation', array( $this, 'jp4wc_email_preview_dummy_product_variation' ), 10 );
 		// Remove WC Additional Checkout Fields API duplicates from My Account address edit form.
 		add_filter( 'woocommerce_address_to_edit', array( $this, 'remove_duplicate_yomigana_from_address_edit' ), 20, 2 );
-		// Suppress WC Additional Fields API rendering on My Account address view for classic checkout.
-		add_action( 'woocommerce_my_account_after_my_address', array( $this, 'suppress_wc_additional_fields_view_on_classic' ), 9 );
+		// Suppress WC Additional Fields API rendering on My Account address view page.
+		add_action( 'woocommerce_my_account_after_my_address', array( $this, 'suppress_wc_additional_fields_on_account_view' ), 9 );
 	}
 
 	/**
@@ -859,7 +859,7 @@ class JP4WC_Address_Fields {
 	}
 
 	/**
-	 * Suppress WC Additional Checkout Fields rendering on My Account address VIEW page.
+	 * Suppress WC Additional Checkout Fields rendering on the My Account address view page.
 	 *
 	 * On the My Account address view page, is_blocks_checkout_context() always returns false,
 	 * so address_formats() always takes the PHP rendering path and includes {yomigana_*} in
@@ -867,28 +867,38 @@ class JP4WC_Address_Fields {
 	 * render_address_fields() (priority 10) would then render yomigana again as a bare
 	 * <br><strong> line, causing a duplicate entry below the formatted address block.
 	 *
-	 * This callback (priority 9) unconditionally removes WC's render_address_fields hook
-	 * whenever yomigana is enabled, preventing the duplicate.
+	 * This callback (priority 9) removes WC's render_address_fields hook whenever yomigana is
+	 * enabled, preventing the duplicate. It runs for both classic and block checkout setups.
 	 *
 	 * @since 2.9.12
 	 * @param string $address_type 'billing' or 'shipping'.
 	 * @return void
 	 */
-	public function suppress_wc_additional_fields_view_on_classic( $address_type ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	public function suppress_wc_additional_fields_on_account_view( $address_type ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		if ( ! get_option( 'wc4jp-yomigana' ) ) {
 			return;
 		}
-		// address_formats() uses PHP rendering on My Account (is_blocks_checkout_context() = false),
-		// so {yomigana_*} is always in the format string — suppress WC's duplicate render_address_fields.
-		global $wp_filter;
-		if ( empty( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] ) ) {
+		$hook     = 'woocommerce_my_account_after_my_address';
+		$priority = 10;
+		// Guard: skip if the hook has no callbacks at all.
+		if ( ! has_action( $hook ) ) {
 			return;
 		}
-		foreach ( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] as $callback_id => $callback_data ) {
+		global $wp_filter;
+		if ( ! isset( $wp_filter[ $hook ] ) || ! ( $wp_filter[ $hook ] instanceof WP_Hook ) ) {
+			return;
+		}
+		// Use remove_action() rather than directly mutating $wp_filter internals.
+		// Iterate over a snapshot so removal does not affect the current loop.
+		foreach ( $wp_filter[ $hook ]->callbacks[ $priority ] ?? array() as $callback_data ) {
 			$fn = $callback_data['function'];
-			if ( is_array( $fn ) && is_object( $fn[0] ) && method_exists( $fn[0], 'render_address_fields' ) ) {
-				unset( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10][ $callback_id ] );
-				// Do not break — WC CheckoutFieldsFrontend may be registered alongside other callbacks.
+			if (
+				is_array( $fn )
+				&& is_object( $fn[0] )
+				&& false !== strpos( get_class( $fn[0] ), 'CheckoutFields' )
+				&& method_exists( $fn[0], 'render_address_fields' )
+			) {
+				remove_action( $hook, $fn, $priority );
 			}
 		}
 	}

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -301,23 +301,24 @@ class JP4WC_Address_Fields {
 		// Block checkout saves to _wc_{type}/jp4wc/* keys; classic checkout saves to {type}_yomigana_* keys.
 		// When both are present (e.g. after switching checkout types), use the key that matches the
 		// current checkout configuration so the most recently entered value is shown.
-		// If checkout page is not configured, fall back to block (WC Additional Fields API) keys first.
-		$checkout_page_id   = wc_get_page_id( 'checkout' );
-		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
+		// When the checkout page is not configured (no page ID), we cannot detect the type and
+		// default to block (WC Additional Fields API) keys, matching the block-preferred fallback.
+		$checkout_page_id     = wc_get_page_id( 'checkout' );
+		$has_classic_checkout = $checkout_page_id && ! has_block( 'woocommerce/checkout', $checkout_page_id );
 
 		$block_last    = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_last_name', true );
 		$block_first   = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_first_name', true );
 		$classic_last  = get_user_meta( $customer_id, $name . '_yomigana_last_name', true );
 		$classic_first = get_user_meta( $customer_id, $name . '_yomigana_first_name', true );
 
-		if ( $has_block_checkout ) {
-			// Block checkout: prefer block keys, fall back to classic.
-			$fields['yomigana_last_name']  = ! empty( $block_last ) ? $block_last : $classic_last;
-			$fields['yomigana_first_name'] = ! empty( $block_first ) ? $block_first : $classic_first;
-		} else {
-			// Classic checkout (or no page configured): prefer classic keys, fall back to block.
+		if ( $has_classic_checkout ) {
+			// Classic checkout: prefer classic keys, fall back to block.
 			$fields['yomigana_last_name']  = ! empty( $classic_last ) ? $classic_last : $block_last;
 			$fields['yomigana_first_name'] = ! empty( $classic_first ) ? $classic_first : $block_first;
+		} else {
+			// Block checkout or no checkout page configured: prefer block keys, fall back to classic.
+			$fields['yomigana_last_name']  = ! empty( $block_last ) ? $block_last : $classic_last;
+			$fields['yomigana_first_name'] = ! empty( $block_first ) ? $block_first : $classic_first;
 		}
 
 		$fields['phone'] = get_user_meta( $customer_id, $name . '_phone', true );

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -888,7 +888,7 @@ class JP4WC_Address_Fields {
 			$fn = $callback_data['function'];
 			if ( is_array( $fn ) && is_object( $fn[0] ) && method_exists( $fn[0], 'render_address_fields' ) ) {
 				unset( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10][ $callback_id ] );
-				break;
+				// Do not break — WC CheckoutFieldsFrontend may be registered alongside other callbacks.
 			}
 		}
 	}

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -297,15 +297,29 @@ class JP4WC_Address_Fields {
 	 * @return array
 	 */
 	public function formatted_address( $fields, $customer_id, $name ) {
-		// Try classic checkout meta key first, then fall back to block checkout (WC Additional Fields API) key.
-		$fields['yomigana_last_name'] = get_user_meta( $customer_id, $name . '_yomigana_last_name', true );
-		if ( empty( $fields['yomigana_last_name'] ) ) {
-			$fields['yomigana_last_name'] = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_last_name', true );
+		// Determine which meta key set to prefer based on the configured checkout type.
+		// Block checkout saves to _wc_{type}/jp4wc/* keys; classic checkout saves to {type}_yomigana_* keys.
+		// When both are present (e.g. after switching checkout types), use the key that matches the
+		// current checkout configuration so the most recently entered value is shown.
+		// If checkout page is not configured, fall back to block (WC Additional Fields API) keys first.
+		$checkout_page_id   = wc_get_page_id( 'checkout' );
+		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
+
+		$block_last    = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_last_name', true );
+		$block_first   = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_first_name', true );
+		$classic_last  = get_user_meta( $customer_id, $name . '_yomigana_last_name', true );
+		$classic_first = get_user_meta( $customer_id, $name . '_yomigana_first_name', true );
+
+		if ( $has_block_checkout ) {
+			// Block checkout: prefer block keys, fall back to classic.
+			$fields['yomigana_last_name']  = ! empty( $block_last ) ? $block_last : $classic_last;
+			$fields['yomigana_first_name'] = ! empty( $block_first ) ? $block_first : $classic_first;
+		} else {
+			// Classic checkout (or no page configured): prefer classic keys, fall back to block.
+			$fields['yomigana_last_name']  = ! empty( $classic_last ) ? $classic_last : $block_last;
+			$fields['yomigana_first_name'] = ! empty( $classic_first ) ? $classic_first : $block_first;
 		}
-		$fields['yomigana_first_name'] = get_user_meta( $customer_id, $name . '_yomigana_first_name', true );
-		if ( empty( $fields['yomigana_first_name'] ) ) {
-			$fields['yomigana_first_name'] = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_first_name', true );
-		}
+
 		$fields['phone'] = get_user_meta( $customer_id, $name . '_phone', true );
 
 		return $fields;

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -297,9 +297,16 @@ class JP4WC_Address_Fields {
 	 * @return array
 	 */
 	public function formatted_address( $fields, $customer_id, $name ) {
+		// Try classic checkout meta key first, then fall back to block checkout (WC Additional Fields API) key.
+		$fields['yomigana_last_name'] = get_user_meta( $customer_id, $name . '_yomigana_last_name', true );
+		if ( empty( $fields['yomigana_last_name'] ) ) {
+			$fields['yomigana_last_name'] = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_last_name', true );
+		}
 		$fields['yomigana_first_name'] = get_user_meta( $customer_id, $name . '_yomigana_first_name', true );
-		$fields['yomigana_last_name']  = get_user_meta( $customer_id, $name . '_yomigana_last_name', true );
-		$fields['phone']               = get_user_meta( $customer_id, $name . '_phone', true );
+		if ( empty( $fields['yomigana_first_name'] ) ) {
+			$fields['yomigana_first_name'] = get_user_meta( $customer_id, '_wc_' . $name . '/jp4wc/yomigana_first_name', true );
+		}
+		$fields['phone'] = get_user_meta( $customer_id, $name . '_phone', true );
 
 		return $fields;
 	}
@@ -852,16 +859,16 @@ class JP4WC_Address_Fields {
 	}
 
 	/**
-	 * Suppress WC Additional Checkout Fields rendering on My Account address VIEW for classic checkout.
+	 * Suppress WC Additional Checkout Fields rendering on My Account address VIEW page.
 	 *
-	 * On classic (or FSE block) checkout sites, yomigana already appears inside the JP-formatted
-	 * address string via address_formats() + formatted_address(). WC's CheckoutFieldsFrontend::
-	 * render_address_fields() (priority 10) would render it again as a bare <br><strong> line,
-	 * causing a duplicate entry below the formatted address block.
+	 * On the My Account address view page, is_blocks_checkout_context() always returns false,
+	 * so address_formats() always takes the PHP rendering path and includes {yomigana_*} in
+	 * the JP format string (both classic and block checkout sites). WC's CheckoutFieldsFrontend::
+	 * render_address_fields() (priority 10) would then render yomigana again as a bare
+	 * <br><strong> line, causing a duplicate entry below the formatted address block.
 	 *
-	 * This callback (priority 9) removes that WC hook before it fires. On non-FSE block checkout
-	 * sites, add_yomigana_fields() returns early so yomigana is absent from the format string and
-	 * WC's rendering is the sole display mechanism — we leave it intact.
+	 * This callback (priority 9) unconditionally removes WC's render_address_fields hook
+	 * whenever yomigana is enabled, preventing the duplicate.
 	 *
 	 * @since 2.9.12
 	 * @param string $address_type 'billing' or 'shipping'.
@@ -871,13 +878,8 @@ class JP4WC_Address_Fields {
 		if ( ! get_option( 'wc4jp-yomigana' ) ) {
 			return;
 		}
-		// On non-FSE block checkout, yomigana is not in the format string — leave WC rendering intact.
-		$checkout_page_id   = wc_get_page_id( 'checkout' );
-		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
-		if ( $has_block_checkout ) {
-			return;
-		}
-		// Classic / FSE checkout: find and remove WC's render_address_fields callback (priority 10).
+		// address_formats() uses PHP rendering on My Account (is_blocks_checkout_context() = false),
+		// so {yomigana_*} is always in the format string — suppress WC's duplicate render_address_fields.
 		global $wp_filter;
 		if ( empty( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] ) ) {
 			return;

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -65,6 +65,8 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_email_preview_dummy_product_variation', array( $this, 'jp4wc_email_preview_dummy_product_variation' ), 10 );
 		// Remove WC Additional Checkout Fields API duplicates from My Account address edit form.
 		add_filter( 'woocommerce_address_to_edit', array( $this, 'remove_duplicate_yomigana_from_address_edit' ), 20, 2 );
+		// Suppress WC Additional Fields API rendering on My Account address view for classic checkout.
+		add_action( 'woocommerce_my_account_after_my_address', array( $this, 'suppress_wc_additional_fields_view_on_classic' ), 9 );
 	}
 
 	/**
@@ -847,6 +849,46 @@ class JP4WC_Address_Fields {
 			}
 		}
 		return $address;
+	}
+
+	/**
+	 * Suppress WC Additional Checkout Fields rendering on My Account address VIEW for classic checkout.
+	 *
+	 * On classic (or FSE block) checkout sites, yomigana already appears inside the JP-formatted
+	 * address string via address_formats() + formatted_address(). WC's CheckoutFieldsFrontend::
+	 * render_address_fields() (priority 10) would render it again as a bare <br><strong> line,
+	 * causing a duplicate entry below the formatted address block.
+	 *
+	 * This callback (priority 9) removes that WC hook before it fires. On non-FSE block checkout
+	 * sites, add_yomigana_fields() returns early so yomigana is absent from the format string and
+	 * WC's rendering is the sole display mechanism — we leave it intact.
+	 *
+	 * @since 2.9.12
+	 * @param string $address_type 'billing' or 'shipping'.
+	 * @return void
+	 */
+	public function suppress_wc_additional_fields_view_on_classic( $address_type ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		if ( ! get_option( 'wc4jp-yomigana' ) ) {
+			return;
+		}
+		// On non-FSE block checkout, yomigana is not in the format string — leave WC rendering intact.
+		$checkout_page_id   = wc_get_page_id( 'checkout' );
+		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
+		if ( $has_block_checkout ) {
+			return;
+		}
+		// Classic / FSE checkout: find and remove WC's render_address_fields callback (priority 10).
+		global $wp_filter;
+		if ( empty( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] ) ) {
+			return;
+		}
+		foreach ( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] as $callback_id => $callback_data ) {
+			$fn = $callback_data['function'];
+			if ( is_array( $fn ) && is_object( $fn[0] ) && method_exists( $fn[0], 'render_address_fields' ) ) {
+				unset( $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10][ $callback_id ] );
+				break;
+			}
+		}
 	}
 }
 // Address Fields Class load.

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -63,6 +63,8 @@ class JP4WC_Address_Fields {
 		add_filter( 'woocommerce_email_preview_dummy_address', array( $this, 'jp4wc_email_preview_dummy_address' ), 10 );
 		add_filter( 'woocommerce_email_preview_dummy_product', array( $this, 'jp4wc_email_preview_dummy_product' ), 10 );
 		add_filter( 'woocommerce_email_preview_dummy_product_variation', array( $this, 'jp4wc_email_preview_dummy_product_variation' ), 10 );
+		// Remove WC Additional Checkout Fields API duplicates from My Account address edit form.
+		add_filter( 'woocommerce_address_to_edit', array( $this, 'remove_duplicate_yomigana_from_address_edit' ), 20, 2 );
 	}
 
 	/**
@@ -807,6 +809,44 @@ class JP4WC_Address_Fields {
 	public function jp4wc_email_preview_dummy_product_variation( $product ) {
 		$product->set_price( 1500 );
 		return $product;
+	}
+
+	/**
+	 * Remove WC Additional Checkout Fields API yomigana duplicates from My Account address edit.
+	 *
+	 * WC's CheckoutFieldsFrontend::edit_address_fields() (priority 10) always injects
+	 * _wc_{type}/jp4wc/* fields into the My Account address edit form. On classic-checkout
+	 * sites (and FSE block-checkout sites where has_block() returns false) JP4WC's own
+	 * {type}_yomigana_* fields are also present, causing a second yomigana row below the
+	 * email field with an incorrect name attribute.
+	 *
+	 * When the traditional {type}_yomigana_last_name field is present we remove the
+	 * WC-added duplicates so only the traditional fields (positioned near the name section)
+	 * remain visible.
+	 *
+	 * On non-FSE block-checkout sites add_yomigana_fields() returns early, so the
+	 * traditional field is absent. In that case this guard is false and the WC-added
+	 * fields are left intact (single display via block API).
+	 *
+	 * @since 2.9.12
+	 * @param array  $address      Address fields array for the edit form.
+	 * @param string $address_type 'billing' or 'shipping'.
+	 * @return array
+	 */
+	public function remove_duplicate_yomigana_from_address_edit( $address, $address_type ) {
+		if ( ! get_option( 'wc4jp-yomigana' ) ) {
+			return $address;
+		}
+		if ( ! isset( $address[ $address_type . '_yomigana_last_name' ] ) ) {
+			return $address;
+		}
+		$namespace_prefix = '_wc_' . $address_type . '/jp4wc/';
+		foreach ( array_keys( $address ) as $key ) {
+			if ( 0 === strpos( $key, $namespace_prefix ) ) {
+				unset( $address[ $key ] );
+			}
+		}
+		return $address;
 	}
 }
 // Address Fields Class load.

--- a/tests/Unit/test-jp4wc-address-email.php
+++ b/tests/Unit/test-jp4wc-address-email.php
@@ -8,6 +8,22 @@
  * @package Japanized_For_WooCommerce
  */
 
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed,Generic.Files.OneObjectStructurePerFile.MultipleFound
+// Test files mix function stubs with multiple class declarations; these rules do not apply here.
+
+// Stub WooCommerce functions that are absent in the minimal WP test environment.
+if ( ! function_exists( 'wc_get_page_id' ) ) {
+	/**
+	 * Stub: returns 0 (no page configured), simulating classic/non-block checkout.
+	 *
+	 * @param string $page Page slug.
+	 * @return int
+	 */
+	function wc_get_page_id( $page ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return 0;
+	}
+}
+
 /**
  * JP4WC_Address_Email_Test
  *
@@ -18,6 +34,9 @@
  */
 class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 
+	/**
+	 * Set up test environment before each test.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 
@@ -26,6 +45,9 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Tear down test environment after each test.
+	 */
 	public function tearDown(): void {
 		delete_option( 'wc4jp-yomigana' );
 		delete_option( 'wc4jp-yomigana-required' );
@@ -147,7 +169,7 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	// ------------------------------------------------------------------
 
 	/**
-	 * address_replacements() must populate {yomigana_*} from the args array.
+	 * Address_replacements() must populate {yomigana_*} from the args array.
 	 */
 	public function test_address_replacements_sets_yomigana_values() {
 		update_option( 'wc4jp-yomigana', '1' );
@@ -168,7 +190,7 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * address_replacements() must not set {yomigana_*} when the option is disabled.
+	 * Address_replacements() must not set {yomigana_*} when the option is disabled.
 	 */
 	public function test_address_replacements_skips_yomigana_when_disabled() {
 		delete_option( 'wc4jp-yomigana' );
@@ -184,7 +206,7 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * address_replacements() must not add honorific suffix for non-JP addresses.
+	 * Address_replacements() must not add honorific suffix for non-JP addresses.
 	 */
 	public function test_address_replacements_does_not_add_honorific_suffix_for_non_jp() {
 		update_option( 'wc4jp-honorific-suffix', '1' );
@@ -324,23 +346,23 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		$af = new JP4WC_Address_Fields();
 
 		$address = array(
-			'billing_last_name'                      => array(
+			'billing_last_name'                     => array(
 				'label' => 'Last Name',
 				'value' => 'Yamada',
 			),
-			'billing_first_name'                     => array(
+			'billing_first_name'                    => array(
 				'label' => 'First Name',
 				'value' => 'Taro',
 			),
-			'billing_yomigana_last_name'             => array(
+			'billing_yomigana_last_name'            => array(
 				'label' => 'Yomigana Last',
 				'value' => 'ヤマダ',
 			),
-			'billing_yomigana_first_name'            => array(
+			'billing_yomigana_first_name'           => array(
 				'label' => 'Yomigana First',
 				'value' => 'タロウ',
 			),
-			'billing_email'                          => array(
+			'billing_email'                         => array(
 				'label' => 'Email',
 				'value' => 'test@example.com',
 			),
@@ -372,15 +394,15 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		$af = new JP4WC_Address_Fields();
 
 		$address = array(
-			'shipping_last_name'                      => array(
+			'shipping_last_name'                     => array(
 				'label' => 'Last Name',
 				'value' => 'Suzuki',
 			),
-			'shipping_yomigana_last_name'             => array(
+			'shipping_yomigana_last_name'            => array(
 				'label' => 'Yomigana Last',
 				'value' => 'スズキ',
 			),
-			'shipping_yomigana_first_name'            => array(
+			'shipping_yomigana_first_name'           => array(
 				'label' => 'Yomigana First',
 				'value' => 'ハナコ',
 			),
@@ -411,11 +433,11 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		$af = new JP4WC_Address_Fields();
 
 		$address = array(
-			'billing_last_name'                      => array(
+			'billing_last_name'                     => array(
 				'label' => 'Last Name',
 				'value' => 'Yamada',
 			),
-			'billing_email'                          => array(
+			'billing_email'                         => array(
 				'label' => 'Email',
 				'value' => 'test@example.com',
 			),
@@ -444,11 +466,11 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		$af = new JP4WC_Address_Fields();
 
 		$address = array(
-			'billing_yomigana_last_name'             => array(
+			'billing_yomigana_last_name'           => array(
 				'label' => 'Yomigana Last',
 				'value' => 'ヤマダ',
 			),
-			'_wc_billing/jp4wc/yomigana_last_name'  => array(
+			'_wc_billing/jp4wc/yomigana_last_name' => array(
 				'label' => 'Yomigana Last',
 				'value' => 'ヤマダ',
 			),
@@ -457,5 +479,81 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		$result = $af->remove_duplicate_yomigana_from_address_edit( $address, 'billing' );
 
 		$this->assertArrayHasKey( '_wc_billing/jp4wc/yomigana_last_name', $result, 'WC-added fields must remain when yomigana option is disabled.' );
+	}
+
+	// ------------------------------------------------------------------
+	// My Account address view: suppress_wc_additional_fields_view_on_classic
+	// ------------------------------------------------------------------
+
+	/**
+	 * On classic checkout with yomigana enabled, a mock render_address_fields callback
+	 * at priority 10 must be removed by suppress_wc_additional_fields_view_on_classic.
+	 *
+	 * The test environment has no WooCommerce/checkout block on the checkout page
+	 * (wc_get_page_id('checkout') returns 0 or a page without that block), so
+	 * has_block() returns false — the classic-checkout suppression path is taken.
+	 */
+	public function test_suppress_removes_wc_render_address_fields_on_classic_checkout() {
+		update_option( 'wc4jp-yomigana', '1' );
+
+		// Simulate WC CheckoutFieldsFrontend having render_address_fields hooked at priority 10.
+		$mock = new JP4WC_Test_CheckoutFieldsFrontend_Mock();
+		add_action( 'woocommerce_my_account_after_my_address', array( $mock, 'render_address_fields' ), 10 );
+
+		$af = new JP4WC_Address_Fields();
+		$af->suppress_wc_additional_fields_view_on_classic( 'billing' );
+
+		// The mock callback must have been removed.
+		global $wp_filter;
+		$callbacks_at_10 = $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] ?? array();
+		foreach ( $callbacks_at_10 as $callback_data ) {
+			$fn = $callback_data['function'];
+			if ( is_array( $fn ) && $fn[0] === $mock ) {
+				$this->fail( 'render_address_fields callback should have been removed on classic checkout.' );
+			}
+		}
+		$this->assertTrue( true, 'render_address_fields callback was correctly removed.' );
+	}
+
+	/**
+	 * When yomigana option is disabled, suppress_wc_additional_fields_view_on_classic
+	 * must leave WC's render_address_fields callback intact.
+	 */
+	public function test_suppress_skips_removal_when_yomigana_disabled() {
+		delete_option( 'wc4jp-yomigana' );
+
+		$mock = new JP4WC_Test_CheckoutFieldsFrontend_Mock();
+		add_action( 'woocommerce_my_account_after_my_address', array( $mock, 'render_address_fields' ), 10 );
+
+		$af = new JP4WC_Address_Fields();
+		$af->suppress_wc_additional_fields_view_on_classic( 'billing' );
+
+		// Callback must still be present.
+		global $wp_filter;
+		$found           = false;
+		$callbacks_at_10 = $wp_filter['woocommerce_my_account_after_my_address']->callbacks[10] ?? array();
+		foreach ( $callbacks_at_10 as $callback_data ) {
+			$fn = $callback_data['function'];
+			if ( is_array( $fn ) && $fn[0] === $mock ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'render_address_fields callback must remain when yomigana option is disabled.' );
+	}
+}
+
+/**
+ * Minimal stand-in for WC CheckoutFieldsFrontend — provides render_address_fields()
+ * so method_exists() detection inside suppress_wc_additional_fields_view_on_classic works.
+ */
+class JP4WC_Test_CheckoutFieldsFrontend_Mock {
+	/**
+	 * Stub render_address_fields — intentionally empty for detection testing only.
+	 *
+	 * @param string $address_type Address type (billing or shipping).
+	 * @return void
+	 */
+	public function render_address_fields( $address_type ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	}
 }

--- a/tests/Unit/test-jp4wc-address-email.php
+++ b/tests/Unit/test-jp4wc-address-email.php
@@ -206,7 +206,7 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Address_replacements() must not add honorific suffix for non-JP addresses.
+	 * address_replacements() must not add honorific suffix for non-JP addresses.
 	 */
 	public function test_address_replacements_does_not_add_honorific_suffix_for_non_jp() {
 		update_option( 'wc4jp-honorific-suffix', '1' );

--- a/tests/Unit/test-jp4wc-address-email.php
+++ b/tests/Unit/test-jp4wc-address-email.php
@@ -169,7 +169,7 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	// ------------------------------------------------------------------
 
 	/**
-	 * Address_replacements() must populate {yomigana_*} from the args array.
+	 * address_replacements() must populate {yomigana_*} from the args array.
 	 */
 	public function test_address_replacements_sets_yomigana_values() {
 		update_option( 'wc4jp-yomigana', '1' );
@@ -482,12 +482,12 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// My Account address view: suppress_wc_additional_fields_view_on_classic
+	// My Account address view: suppress_wc_additional_fields_on_account_view
 	// ------------------------------------------------------------------
 
 	/**
 	 * On classic checkout with yomigana enabled, a mock render_address_fields callback
-	 * at priority 10 must be removed by suppress_wc_additional_fields_view_on_classic.
+	 * at priority 10 must be removed by suppress_wc_additional_fields_on_account_view.
 	 *
 	 * The test environment has no WooCommerce/checkout block on the checkout page
 	 * (wc_get_page_id('checkout') returns 0 or a page without that block), so
@@ -497,11 +497,11 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		update_option( 'wc4jp-yomigana', '1' );
 
 		// Simulate WC CheckoutFieldsFrontend having render_address_fields hooked at priority 10.
-		$mock = new JP4WC_Test_CheckoutFieldsFrontend_Mock();
+		$mock = new JP4WC_Test_CheckoutFields_Mock();
 		add_action( 'woocommerce_my_account_after_my_address', array( $mock, 'render_address_fields' ), 10 );
 
 		$af = new JP4WC_Address_Fields();
-		$af->suppress_wc_additional_fields_view_on_classic( 'billing' );
+		$af->suppress_wc_additional_fields_on_account_view( 'billing' );
 
 		// The mock callback must have been removed.
 		global $wp_filter;
@@ -516,17 +516,17 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When yomigana option is disabled, suppress_wc_additional_fields_view_on_classic
+	 * When yomigana option is disabled, suppress_wc_additional_fields_on_account_view
 	 * must leave WC's render_address_fields callback intact.
 	 */
 	public function test_suppress_skips_removal_when_yomigana_disabled() {
 		delete_option( 'wc4jp-yomigana' );
 
-		$mock = new JP4WC_Test_CheckoutFieldsFrontend_Mock();
+		$mock = new JP4WC_Test_CheckoutFields_Mock();
 		add_action( 'woocommerce_my_account_after_my_address', array( $mock, 'render_address_fields' ), 10 );
 
 		$af = new JP4WC_Address_Fields();
-		$af->suppress_wc_additional_fields_view_on_classic( 'billing' );
+		$af->suppress_wc_additional_fields_on_account_view( 'billing' );
 
 		// Callback must still be present.
 		global $wp_filter;
@@ -545,9 +545,9 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 
 /**
  * Minimal stand-in for WC CheckoutFieldsFrontend — provides render_address_fields()
- * so method_exists() detection inside suppress_wc_additional_fields_view_on_classic works.
+ * so method_exists() detection inside suppress_wc_additional_fields_on_account_view works.
  */
-class JP4WC_Test_CheckoutFieldsFrontend_Mock {
+class JP4WC_Test_CheckoutFields_Mock {
 	/**
 	 * Stub render_address_fields — intentionally empty for detection testing only.
 	 *

--- a/tests/Unit/test-jp4wc-address-email.php
+++ b/tests/Unit/test-jp4wc-address-email.php
@@ -27,12 +27,13 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		parent::tearDown();
 		delete_option( 'wc4jp-yomigana' );
 		delete_option( 'wc4jp-yomigana-required' );
 		delete_option( 'wc4jp-honorific-suffix' );
 		delete_option( 'wc4jp-company-name' );
+		parent::tearDown();
 	}
+
 
 	// ------------------------------------------------------------------
 	// Layer 1: woocommerce_localisation_address_formats filter registration
@@ -305,5 +306,156 @@ class JP4WC_Address_Email_Test extends WP_UnitTestCase {
 		);
 
 		$order->delete( true );
+	}
+
+	// ------------------------------------------------------------------
+	// My Account address edit: remove_duplicate_yomigana_from_address_edit
+	// ------------------------------------------------------------------
+
+	/**
+	 * When traditional yomigana fields are present, WC-added _wc_billing/jp4wc/* duplicates
+	 * must be removed so only one yomigana row appears in My Account billing address edit.
+	 */
+	public function test_duplicate_wc_added_yomigana_removed_from_billing_address_edit() {
+		update_option( 'wc4jp-yomigana', '1' );
+
+		// Call the method directly to avoid WP_UnitTestCase's _restore_hooks() resetting
+		// $wp_filter between tests — the hook state is unreliable across test methods.
+		$af = new JP4WC_Address_Fields();
+
+		$address = array(
+			'billing_last_name'                      => array(
+				'label' => 'Last Name',
+				'value' => 'Yamada',
+			),
+			'billing_first_name'                     => array(
+				'label' => 'First Name',
+				'value' => 'Taro',
+			),
+			'billing_yomigana_last_name'             => array(
+				'label' => 'Yomigana Last',
+				'value' => 'ヤマダ',
+			),
+			'billing_yomigana_first_name'            => array(
+				'label' => 'Yomigana First',
+				'value' => 'タロウ',
+			),
+			'billing_email'                          => array(
+				'label' => 'Email',
+				'value' => 'test@example.com',
+			),
+			'_wc_billing/jp4wc/yomigana_last_name'  => array(
+				'label' => 'Yomigana Last',
+				'value' => 'ヤマダ',
+			),
+			'_wc_billing/jp4wc/yomigana_first_name' => array(
+				'label' => 'Yomigana First',
+				'value' => 'タロウ',
+			),
+		);
+
+		$result = $af->remove_duplicate_yomigana_from_address_edit( $address, 'billing' );
+
+		$this->assertArrayHasKey( 'billing_yomigana_last_name', $result, 'Traditional yomigana_last_name must remain.' );
+		$this->assertArrayHasKey( 'billing_yomigana_first_name', $result, 'Traditional yomigana_first_name must remain.' );
+		$this->assertArrayNotHasKey( '_wc_billing/jp4wc/yomigana_last_name', $result, 'WC-added _wc_billing/jp4wc/yomigana_last_name must be removed.' );
+		$this->assertArrayNotHasKey( '_wc_billing/jp4wc/yomigana_first_name', $result, 'WC-added _wc_billing/jp4wc/yomigana_first_name must be removed.' );
+	}
+
+	/**
+	 * When traditional yomigana fields are present, WC-added _wc_shipping/jp4wc/* duplicates
+	 * must be removed from the shipping address edit form.
+	 */
+	public function test_duplicate_wc_added_yomigana_removed_from_shipping_address_edit() {
+		update_option( 'wc4jp-yomigana', '1' );
+
+		$af = new JP4WC_Address_Fields();
+
+		$address = array(
+			'shipping_last_name'                      => array(
+				'label' => 'Last Name',
+				'value' => 'Suzuki',
+			),
+			'shipping_yomigana_last_name'             => array(
+				'label' => 'Yomigana Last',
+				'value' => 'スズキ',
+			),
+			'shipping_yomigana_first_name'            => array(
+				'label' => 'Yomigana First',
+				'value' => 'ハナコ',
+			),
+			'_wc_shipping/jp4wc/yomigana_last_name'  => array(
+				'label' => 'Yomigana Last',
+				'value' => 'スズキ',
+			),
+			'_wc_shipping/jp4wc/yomigana_first_name' => array(
+				'label' => 'Yomigana First',
+				'value' => 'ハナコ',
+			),
+		);
+
+		$result = $af->remove_duplicate_yomigana_from_address_edit( $address, 'shipping' );
+
+		$this->assertArrayHasKey( 'shipping_yomigana_last_name', $result, 'Traditional shipping_yomigana_last_name must remain.' );
+		$this->assertArrayNotHasKey( '_wc_shipping/jp4wc/yomigana_last_name', $result, 'WC-added _wc_shipping/jp4wc/yomigana_last_name must be removed.' );
+		$this->assertArrayNotHasKey( '_wc_shipping/jp4wc/yomigana_first_name', $result, 'WC-added _wc_shipping/jp4wc/yomigana_first_name must be removed.' );
+	}
+
+	/**
+	 * When traditional yomigana fields are absent (block checkout, non-FSE theme),
+	 * the WC-added _wc_billing/jp4wc/* fields must be kept intact (single display).
+	 */
+	public function test_wc_added_yomigana_kept_when_traditional_fields_absent() {
+		update_option( 'wc4jp-yomigana', '1' );
+
+		$af = new JP4WC_Address_Fields();
+
+		$address = array(
+			'billing_last_name'                      => array(
+				'label' => 'Last Name',
+				'value' => 'Yamada',
+			),
+			'billing_email'                          => array(
+				'label' => 'Email',
+				'value' => 'test@example.com',
+			),
+			'_wc_billing/jp4wc/yomigana_last_name'  => array(
+				'label' => 'Yomigana Last',
+				'value' => 'ヤマダ',
+			),
+			'_wc_billing/jp4wc/yomigana_first_name' => array(
+				'label' => 'Yomigana First',
+				'value' => 'タロウ',
+			),
+		);
+
+		$result = $af->remove_duplicate_yomigana_from_address_edit( $address, 'billing' );
+
+		$this->assertArrayHasKey( '_wc_billing/jp4wc/yomigana_last_name', $result, 'WC-added fields must remain when traditional fields are absent (block checkout).' );
+		$this->assertArrayHasKey( '_wc_billing/jp4wc/yomigana_first_name', $result, 'WC-added fields must remain when traditional fields are absent (block checkout).' );
+	}
+
+	/**
+	 * When yomigana option is disabled, no fields are removed.
+	 */
+	public function test_address_edit_deduplication_skipped_when_yomigana_disabled() {
+		delete_option( 'wc4jp-yomigana' );
+
+		$af = new JP4WC_Address_Fields();
+
+		$address = array(
+			'billing_yomigana_last_name'             => array(
+				'label' => 'Yomigana Last',
+				'value' => 'ヤマダ',
+			),
+			'_wc_billing/jp4wc/yomigana_last_name'  => array(
+				'label' => 'Yomigana Last',
+				'value' => 'ヤマダ',
+			),
+		);
+
+		$result = $af->remove_duplicate_yomigana_from_address_edit( $address, 'billing' );
+
+		$this->assertArrayHasKey( '_wc_billing/jp4wc/yomigana_last_name', $result, 'WC-added fields must remain when yomigana option is disabled.' );
 	}
 }

--- a/tests/e2e/myaccount-address.spec.ts
+++ b/tests/e2e/myaccount-address.spec.ts
@@ -12,80 +12,20 @@
  * Fields API (_wc_billing/jp4wc/yomigana_last_name) field — no traditional
  * field is added, so the WC-managed field is the single source of truth.
  */
-import { test, expect, type APIRequestContext } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
+import { test, expect } from '@playwright/test';
 import {
 	ADMIN_USER,
 	ADMIN_PASS,
+	getJp4wcSettings,
 	setJp4wcSettings,
 	wpFetch,
+	wcGet,
+	wcPut,
+	getCheckoutPageId,
+	setCheckoutPageId,
 } from './utils/helpers';
 
 const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
-
-// ---------------------------------------------------------------------------
-// Auth helper
-// ---------------------------------------------------------------------------
-
-function getAuth(): string {
-	// Prefer env var (set by global-setup in the same process).
-	if ( process.env.WP_APP_PASSWORD ) {
-		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
-	}
-	// Fallback: read from credentials file written by global-setup.ts.
-	const credFile = path.resolve( __dirname, '.auth/credentials.json' );
-	if ( fs.existsSync( credFile ) ) {
-		const creds = JSON.parse( fs.readFileSync( credFile, 'utf8' ) ) as { user: string; appPassword: string };
-		return Buffer.from( `${ creds.user }:${ creds.appPassword }` ).toString( 'base64' );
-	}
-	return Buffer.from( `${ ADMIN_USER }:${ ADMIN_PASS }` ).toString( 'base64' );
-}
-
-// ---------------------------------------------------------------------------
-// REST helpers (scoped to this file for clarity)
-// ---------------------------------------------------------------------------
-
-async function wcPut(
-	request: APIRequestContext,
-	endpoint: string,
-	body: object,
-): Promise<unknown> {
-	const res = await request.put( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
-		headers: {
-			Authorization: `Basic ${ getAuth() }`,
-			'Content-Type': 'application/json',
-		},
-		data: JSON.stringify( body ),
-	} );
-	return res.json();
-}
-
-async function wcGet(
-	request: APIRequestContext,
-	endpoint: string,
-): Promise<unknown> {
-	const res = await request.get( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
-		headers: { Authorization: `Basic ${ getAuth() }` },
-	} );
-	return res.json();
-}
-
-/** Get the current WC checkout page ID from settings. */
-async function getCheckoutPageId( request: APIRequestContext ): Promise<string> {
-	const settings = ( await wcGet( request, 'settings/advanced' ) ) as { id: string; value: string }[];
-	return settings.find( ( s ) => s.id === 'woocommerce_checkout_page_id' )?.value ?? '';
-}
-
-/** Set the WC checkout page ID in settings. */
-async function setCheckoutPageId(
-	request: APIRequestContext,
-	pageId: string | number,
-): Promise<void> {
-	await wcPut( request, 'settings/advanced/woocommerce_checkout_page_id', {
-		value: String( pageId ),
-	} );
-}
 
 // ---------------------------------------------------------------------------
 // Page content constants
@@ -103,12 +43,15 @@ const BLOCK_CHECKOUT_CONTENT =
 
 test.describe( 'My Account address edit — yomigana deduplication', () => {
 	let originalCheckoutPageId: string;
+	let originalYomigana: string;
 	let classicPageId: number;
 	let blockPageId: number;
 
 	test.beforeAll( async ( { request } ) => {
-		// Save the original checkout page ID so we can restore it after.
-		originalCheckoutPageId = await getCheckoutPageId( request );
+		// Save original settings so we can restore them after.
+		originalCheckoutPageId = await getCheckoutPageId( request, BASE_URL );
+		const settings = await getJp4wcSettings( request, BASE_URL );
+		originalYomigana = ( settings.yomigana as string ) ?? '';
 
 		// Enable yomigana in JP4WC settings.
 		await setJp4wcSettings( request, BASE_URL, { yomigana: '1' } );
@@ -131,9 +74,10 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	} );
 
 	test.afterAll( async ( { request } ) => {
-		// Restore original checkout page.
+		// Restore original settings.
+		await setJp4wcSettings( request, BASE_URL, { yomigana: originalYomigana } );
 		if ( originalCheckoutPageId ) {
-			await setCheckoutPageId( request, originalCheckoutPageId );
+			await setCheckoutPageId( request, BASE_URL, originalCheckoutPageId );
 		}
 
 		// Clean up test pages.
@@ -149,7 +93,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	// -----------------------------------------------------------------------
 
 	test( 'Classic: billing edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
-		await setCheckoutPageId( request, classicPageId );
+		await setCheckoutPageId( request, BASE_URL, classicPageId );
 
 		// Log in as admin via the login form.
 		await page.goto( `${ BASE_URL }/wp-login.php` );
@@ -178,7 +122,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	} );
 
 	test( 'Classic: shipping edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
-		await setCheckoutPageId( request, classicPageId );
+		await setCheckoutPageId( request, BASE_URL, classicPageId );
 
 		await page.goto( `${ BASE_URL }/wp-login.php` );
 		await page.fill( '#user_login', ADMIN_USER );
@@ -205,7 +149,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	// -----------------------------------------------------------------------
 
 	test( 'Block: billing edit shows only WC-API yomigana (no traditional duplicate)', async ( { page, request } ) => {
-		await setCheckoutPageId( request, blockPageId );
+		await setCheckoutPageId( request, BASE_URL, blockPageId );
 
 		await page.goto( `${ BASE_URL }/wp-login.php` );
 		await page.fill( '#user_login', ADMIN_USER );

--- a/tests/e2e/myaccount-address.spec.ts
+++ b/tests/e2e/myaccount-address.spec.ts
@@ -14,13 +14,10 @@
  */
 import { test, expect } from '@playwright/test';
 import {
-	ADMIN_USER,
-	ADMIN_PASS,
+	login,
 	getJp4wcSettings,
 	setJp4wcSettings,
 	wpFetch,
-	wcGet,
-	wcPut,
 	getCheckoutPageId,
 	setCheckoutPageId,
 } from './utils/helpers';
@@ -95,12 +92,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	test( 'Classic: billing edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
 		await setCheckoutPageId( request, BASE_URL, classicPageId );
 
-		// Log in as admin via the login form.
-		await page.goto( `${ BASE_URL }/wp-login.php` );
-		await page.fill( '#user_login', ADMIN_USER );
-		await page.fill( '#user_pass', ADMIN_PASS );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( /wp-admin/ );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/edit-address/billing/` );
 		await page.waitForLoadState( 'networkidle' );
@@ -124,11 +116,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	test( 'Classic: shipping edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
 		await setCheckoutPageId( request, BASE_URL, classicPageId );
 
-		await page.goto( `${ BASE_URL }/wp-login.php` );
-		await page.fill( '#user_login', ADMIN_USER );
-		await page.fill( '#user_pass', ADMIN_PASS );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( /wp-admin/ );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/edit-address/shipping/` );
 		await page.waitForLoadState( 'networkidle' );
@@ -151,11 +139,7 @@ test.describe( 'My Account address edit — yomigana deduplication', () => {
 	test( 'Block: billing edit shows only WC-API yomigana (no traditional duplicate)', async ( { page, request } ) => {
 		await setCheckoutPageId( request, BASE_URL, blockPageId );
 
-		await page.goto( `${ BASE_URL }/wp-login.php` );
-		await page.fill( '#user_login', ADMIN_USER );
-		await page.fill( '#user_pass', ADMIN_PASS );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( /wp-admin/ );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/edit-address/billing/` );
 		await page.waitForLoadState( 'networkidle' );

--- a/tests/e2e/myaccount-address.spec.ts
+++ b/tests/e2e/myaccount-address.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * E2E tests: My Account address edit form — yomigana deduplication
+ *
+ * Verifies that the yomigana fields appear exactly once in the My Account
+ * address edit form for both classic and block checkout setups.
+ *
+ * Classic checkout: yomigana must appear only via the traditional
+ * billing_yomigana_last_name / billing_yomigana_first_name fields
+ * (positioned near the name section, NOT duplicated below email).
+ *
+ * Block checkout: yomigana must appear only via the WC Additional Checkout
+ * Fields API (_wc_billing/jp4wc/yomigana_last_name) field — no traditional
+ * field is added, so the WC-managed field is the single source of truth.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import {
+	ADMIN_USER,
+	ADMIN_PASS,
+	setJp4wcSettings,
+	wpFetch,
+} from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+function getAuth(): string {
+	// Prefer env var (set by global-setup in the same process).
+	if ( process.env.WP_APP_PASSWORD ) {
+		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
+	}
+	// Fallback: read from credentials file written by global-setup.ts.
+	const credFile = path.resolve( __dirname, '.auth/credentials.json' );
+	if ( fs.existsSync( credFile ) ) {
+		const creds = JSON.parse( fs.readFileSync( credFile, 'utf8' ) ) as { user: string; appPassword: string };
+		return Buffer.from( `${ creds.user }:${ creds.appPassword }` ).toString( 'base64' );
+	}
+	return Buffer.from( `${ ADMIN_USER }:${ ADMIN_PASS }` ).toString( 'base64' );
+}
+
+// ---------------------------------------------------------------------------
+// REST helpers (scoped to this file for clarity)
+// ---------------------------------------------------------------------------
+
+async function wcPut(
+	request: APIRequestContext,
+	endpoint: string,
+	body: object,
+): Promise<unknown> {
+	const res = await request.put( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: {
+			Authorization: `Basic ${ getAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: JSON.stringify( body ),
+	} );
+	return res.json();
+}
+
+async function wcGet(
+	request: APIRequestContext,
+	endpoint: string,
+): Promise<unknown> {
+	const res = await request.get( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: { Authorization: `Basic ${ getAuth() }` },
+	} );
+	return res.json();
+}
+
+/** Get the current WC checkout page ID from settings. */
+async function getCheckoutPageId( request: APIRequestContext ): Promise<string> {
+	const settings = ( await wcGet( request, 'settings/advanced' ) ) as { id: string; value: string }[];
+	return settings.find( ( s ) => s.id === 'woocommerce_checkout_page_id' )?.value ?? '';
+}
+
+/** Set the WC checkout page ID in settings. */
+async function setCheckoutPageId(
+	request: APIRequestContext,
+	pageId: string | number,
+): Promise<void> {
+	await wcPut( request, 'settings/advanced/woocommerce_checkout_page_id', {
+		value: String( pageId ),
+	} );
+}
+
+// ---------------------------------------------------------------------------
+// Page content constants
+// ---------------------------------------------------------------------------
+
+const CLASSIC_CHECKOUT_CONTENT =
+	`<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->`;
+
+const BLOCK_CHECKOUT_CONTENT =
+	`<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} --><div class="wp-block-woocommerce-checkout is-loading"></div><!-- /wp:woocommerce/checkout -->`;
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+test.describe( 'My Account address edit — yomigana deduplication', () => {
+	let originalCheckoutPageId: string;
+	let classicPageId: number;
+	let blockPageId: number;
+
+	test.beforeAll( async ( { request } ) => {
+		// Save the original checkout page ID so we can restore it after.
+		originalCheckoutPageId = await getCheckoutPageId( request );
+
+		// Enable yomigana in JP4WC settings.
+		await setJp4wcSettings( request, BASE_URL, { yomigana: '1' } );
+
+		// Create a classic checkout page (shortcode).
+		const classicPage = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+			title: 'Classic Checkout (e2e yomigana)',
+			status: 'publish',
+			content: CLASSIC_CHECKOUT_CONTENT,
+		} ) as { id: number };
+		classicPageId = classicPage.id;
+
+		// Create a block checkout page.
+		const blockPage = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+			title: 'Block Checkout (e2e yomigana)',
+			status: 'publish',
+			content: BLOCK_CHECKOUT_CONTENT,
+		} ) as { id: number };
+		blockPageId = blockPage.id;
+	} );
+
+	test.afterAll( async ( { request } ) => {
+		// Restore original checkout page.
+		if ( originalCheckoutPageId ) {
+			await setCheckoutPageId( request, originalCheckoutPageId );
+		}
+
+		// Clean up test pages.
+		for ( const id of [ classicPageId, blockPageId ] ) {
+			if ( id ) {
+				await wpFetch( request, BASE_URL, `pages/${ id }?force=true`, 'DELETE' );
+			}
+		}
+	} );
+
+	// -----------------------------------------------------------------------
+	// Classic checkout
+	// -----------------------------------------------------------------------
+
+	test( 'Classic: billing edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
+		await setCheckoutPageId( request, classicPageId );
+
+		// Log in as admin via the login form.
+		await page.goto( `${ BASE_URL }/wp-login.php` );
+		await page.fill( '#user_login', ADMIN_USER );
+		await page.fill( '#user_pass', ADMIN_PASS );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( /wp-admin/ );
+
+		await page.goto( `${ BASE_URL }/my-account/edit-address/billing/` );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Traditional field must be present.
+		const traditionalLast  = page.locator( 'input[name="billing_yomigana_last_name"]' );
+		const traditionalFirst = page.locator( 'input[name="billing_yomigana_first_name"]' );
+		await expect( traditionalLast ).toHaveCount( 1 );
+		await expect( traditionalFirst ).toHaveCount( 1 );
+
+		// WC Additional Fields API duplicates must be absent.
+		const wcLast  = page.locator( 'input[name="_wc_billing/jp4wc/yomigana_last_name"]' );
+		const wcFirst = page.locator( 'input[name="_wc_billing/jp4wc/yomigana_first_name"]' );
+		await expect( wcLast ).toHaveCount( 0 );
+		await expect( wcFirst ).toHaveCount( 0 );
+
+		// Save a full-page screenshot for visual verification.
+		await page.screenshot( { path: 'test-results/classic-billing-edit-form.png', fullPage: true } );
+	} );
+
+	test( 'Classic: shipping edit shows only traditional yomigana (no WC-API duplicate)', async ( { page, request } ) => {
+		await setCheckoutPageId( request, classicPageId );
+
+		await page.goto( `${ BASE_URL }/wp-login.php` );
+		await page.fill( '#user_login', ADMIN_USER );
+		await page.fill( '#user_pass', ADMIN_PASS );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( /wp-admin/ );
+
+		await page.goto( `${ BASE_URL }/my-account/edit-address/shipping/` );
+		await page.waitForLoadState( 'networkidle' );
+
+		const traditionalLast  = page.locator( 'input[name="shipping_yomigana_last_name"]' );
+		const traditionalFirst = page.locator( 'input[name="shipping_yomigana_first_name"]' );
+		await expect( traditionalLast ).toHaveCount( 1 );
+		await expect( traditionalFirst ).toHaveCount( 1 );
+
+		const wcLast  = page.locator( 'input[name="_wc_shipping/jp4wc/yomigana_last_name"]' );
+		const wcFirst = page.locator( 'input[name="_wc_shipping/jp4wc/yomigana_first_name"]' );
+		await expect( wcLast ).toHaveCount( 0 );
+		await expect( wcFirst ).toHaveCount( 0 );
+	} );
+
+	// -----------------------------------------------------------------------
+	// Block checkout
+	// -----------------------------------------------------------------------
+
+	test( 'Block: billing edit shows only WC-API yomigana (no traditional duplicate)', async ( { page, request } ) => {
+		await setCheckoutPageId( request, blockPageId );
+
+		await page.goto( `${ BASE_URL }/wp-login.php` );
+		await page.fill( '#user_login', ADMIN_USER );
+		await page.fill( '#user_pass', ADMIN_PASS );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( /wp-admin/ );
+
+		await page.goto( `${ BASE_URL }/my-account/edit-address/billing/` );
+		await page.waitForLoadState( 'networkidle' );
+
+		// WC Additional Fields API field must be present.
+		const wcLast  = page.locator( 'input[name="_wc_billing/jp4wc/yomigana_last_name"]' );
+		const wcFirst = page.locator( 'input[name="_wc_billing/jp4wc/yomigana_first_name"]' );
+		await expect( wcLast ).toHaveCount( 1 );
+		await expect( wcFirst ).toHaveCount( 1 );
+
+		// Traditional fields must be absent (block checkout doesn't add them).
+		const traditionalLast  = page.locator( 'input[name="billing_yomigana_last_name"]' );
+		const traditionalFirst = page.locator( 'input[name="billing_yomigana_first_name"]' );
+		await expect( traditionalLast ).toHaveCount( 0 );
+		await expect( traditionalFirst ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/myaccount-view.spec.ts
+++ b/tests/e2e/myaccount-view.spec.ts
@@ -9,98 +9,21 @@
  * address string (address_formats + formatted_address). WC Additional Fields API
  * render_address_fields() must NOT output a duplicate below the formatted block.
  */
-import { test, expect, type APIRequestContext } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
+import { test, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import {
 	ADMIN_USER,
 	ADMIN_PASS,
+	getJp4wcSettings,
 	setJp4wcSettings,
 	wpFetch,
+	wcPut,
+	getCheckoutPageId,
+	setCheckoutPageId,
+	setCustomerAddress,
 } from './utils/helpers';
 
 const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
-
-// ---------------------------------------------------------------------------
-// Auth helper
-// ---------------------------------------------------------------------------
-
-function getAuth(): string {
-	if ( process.env.WP_APP_PASSWORD ) {
-		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
-	}
-	const credFile = path.resolve( __dirname, '.auth/credentials.json' );
-	if ( fs.existsSync( credFile ) ) {
-		const creds = JSON.parse( fs.readFileSync( credFile, 'utf8' ) ) as { user: string; appPassword: string };
-		return Buffer.from( `${ creds.user }:${ creds.appPassword }` ).toString( 'base64' );
-	}
-	return Buffer.from( `${ ADMIN_USER }:${ ADMIN_PASS }` ).toString( 'base64' );
-}
-
-// ---------------------------------------------------------------------------
-// REST helpers
-// ---------------------------------------------------------------------------
-
-async function wcPut(
-	request: APIRequestContext,
-	endpoint: string,
-	body: object,
-): Promise<unknown> {
-	const res = await request.put( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
-		headers: {
-			Authorization: `Basic ${ getAuth() }`,
-			'Content-Type': 'application/json',
-		},
-		data: JSON.stringify( body ),
-	} );
-	return res.json();
-}
-
-async function wcGet(
-	request: APIRequestContext,
-	endpoint: string,
-): Promise<unknown> {
-	const res = await request.get( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
-		headers: { Authorization: `Basic ${ getAuth() }` },
-	} );
-	return res.json();
-}
-
-async function getCheckoutPageId( request: APIRequestContext ): Promise<string> {
-	const settings = ( await wcGet( request, 'settings/advanced' ) ) as { id: string; value: string }[];
-	return settings.find( ( s ) => s.id === 'woocommerce_checkout_page_id' )?.value ?? '';
-}
-
-async function setCheckoutPageId(
-	request: APIRequestContext,
-	pageId: string | number,
-): Promise<void> {
-	await wcPut( request, 'settings/advanced/woocommerce_checkout_page_id', {
-		value: String( pageId ),
-	} );
-}
-
-/** Set billing or shipping address for a WC customer (user ID). */
-async function setCustomerAddress(
-	request: APIRequestContext,
-	customerId: number,
-	type: 'billing' | 'shipping',
-	address: Record< string, string >,
-): Promise<void> {
-	await wcPut( request, `customers/${ customerId }`, { [ type ]: address } );
-}
-
-/**
- * Set arbitrary usermeta via wp-env CLI (WP REST API doesn't expose unregistered meta keys).
- * Uses the tests-cli container so it targets the test environment (port 8891).
- */
-function setUserMetaCli( userId: number, key: string, value: string ): void {
-	execSync(
-		`npx wp-env run tests-cli wp user meta update ${ userId } "${ key }" "${ value }"`,
-		{ stdio: 'pipe' },
-	);
-}
 
 // ---------------------------------------------------------------------------
 // Page content constants
@@ -113,20 +36,39 @@ const BLOCK_CHECKOUT_CONTENT =
 	`<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} --><div class="wp-block-woocommerce-checkout is-loading"></div><!-- /wp:woocommerce/checkout -->`;
 
 // ---------------------------------------------------------------------------
+// CLI helper — set user meta via wp-env (WP REST API doesn't expose custom meta keys)
+// ---------------------------------------------------------------------------
+
+/**
+ * Set arbitrary usermeta via wp-env CLI.
+ * Uses the tests-cli container targeting the test environment (port 8891).
+ */
+function setUserMetaCli( userId: number, key: string, value: string ): void {
+	execSync(
+		`npx wp-env run tests-cli wp user meta update ${ userId } "${ key }" "${ value }"`,
+		{ stdio: 'pipe' },
+	);
+}
+
+// ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
 
 test.describe( 'My Account address view — yomigana deduplication', () => {
 	let originalCheckoutPageId: string;
+	let originalYomigana: string;
 	let classicPageId: number;
 	let blockPageId: number;
 
 	test.beforeAll( async ( { request } ) => {
-		originalCheckoutPageId = await getCheckoutPageId( request );
+		// Save original settings so we can restore them after.
+		originalCheckoutPageId = await getCheckoutPageId( request, BASE_URL );
+		const settings = await getJp4wcSettings( request, BASE_URL );
+		originalYomigana = ( settings.yomigana as string ) ?? '';
 
 		await setJp4wcSettings( request, BASE_URL, { yomigana: '1' } );
 
-		// Seed a complete billing + shipping address for admin (customer ID 1) via WC REST API.
+		// Seed a complete billing + shipping address for admin (customer ID 1).
 		// Without a full address, WC shows "You have not set up this type of address yet"
 		// and render_address_fields is never invoked, making the duplicate test trivial.
 		const baseAddress = {
@@ -138,8 +80,8 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 			postcode: '675-0001',
 			country: 'JP',
 		};
-		await setCustomerAddress( request, 1, 'billing', { ...baseAddress, email: 'test@example.com', phone: '090-1234-5678' } );
-		await setCustomerAddress( request, 1, 'shipping', baseAddress );
+		await setCustomerAddress( request, BASE_URL, 1, 'billing', { ...baseAddress, email: 'test@example.com', phone: '090-1234-5678' } );
+		await setCustomerAddress( request, BASE_URL, 1, 'shipping', baseAddress );
 
 		// Seed yomigana usermeta via wp-cli (WC REST API does not expose these custom meta keys).
 		for ( const type of [ 'billing', 'shipping' ] ) {
@@ -163,9 +105,13 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 	} );
 
 	test.afterAll( async ( { request } ) => {
+		// Restore original settings.
+		await setJp4wcSettings( request, BASE_URL, { yomigana: originalYomigana } );
 		if ( originalCheckoutPageId ) {
-			await setCheckoutPageId( request, originalCheckoutPageId );
+			await setCheckoutPageId( request, BASE_URL, originalCheckoutPageId );
 		}
+
+		// Clean up test pages.
 		for ( const id of [ classicPageId, blockPageId ] ) {
 			if ( id ) {
 				await wpFetch( request, BASE_URL, `pages/${ id }?force=true`, 'DELETE' );
@@ -186,7 +132,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 	// -----------------------------------------------------------------------
 
 	test( 'Classic: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
-		await setCheckoutPageId( request, classicPageId );
+		await setCheckoutPageId( request, BASE_URL, classicPageId );
 		await loginAsAdmin( page );
 
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
@@ -198,7 +144,6 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 		await expect( page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' ) ).toContainText( 'やまだ' );
 
 		// WC's render_address_fields must NOT add a bare "Last Name ( Yomigana ): やまだ" line.
-		// If the duplicate is present, this label appears as <strong> text.
 		const wcApiLabels = page.locator( 'text="Last Name ( Yomigana )"' );
 		await expect( wcApiLabels ).toHaveCount( 0 );
 	} );
@@ -208,7 +153,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 	// -----------------------------------------------------------------------
 
 	test( 'Block: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
-		await setCheckoutPageId( request, blockPageId );
+		await setCheckoutPageId( request, BASE_URL, blockPageId );
 		await loginAsAdmin( page );
 
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
@@ -227,7 +172,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 	// -----------------------------------------------------------------------
 
 	test( 'Block (WC API meta): address view shows yomigana from _wc_billing/jp4wc/ keys', async ( { page, request } ) => {
-		await setCheckoutPageId( request, blockPageId );
+		await setCheckoutPageId( request, BASE_URL, blockPageId );
 
 		// Replace classic meta keys with WC Additional Fields API meta keys.
 		for ( const type of [ 'billing', 'shipping' ] ) {
@@ -251,7 +196,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 		const wcApiLabels = page.locator( 'text="Last Name ( Yomigana )"' );
 		await expect( wcApiLabels ).toHaveCount( 0 );
 
-		// Restore classic meta keys for subsequent tests.
+		// Restore classic meta keys.
 		for ( const type of [ 'billing', 'shipping' ] ) {
 			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ' );
 			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう' );

--- a/tests/e2e/myaccount-view.spec.ts
+++ b/tests/e2e/myaccount-view.spec.ts
@@ -12,12 +12,10 @@
 import { test, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import {
-	ADMIN_USER,
-	ADMIN_PASS,
+	login,
 	getJp4wcSettings,
 	setJp4wcSettings,
 	wpFetch,
-	wcPut,
 	getCheckoutPageId,
 	setCheckoutPageId,
 	setCustomerAddress,
@@ -119,21 +117,13 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 		}
 	} );
 
-	async function loginAsAdmin( page: import('@playwright/test').Page ): Promise<void> {
-		await page.goto( `${ BASE_URL }/wp-login.php` );
-		await page.fill( '#user_login', ADMIN_USER );
-		await page.fill( '#user_pass', ADMIN_PASS );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( /wp-admin/ );
-	}
-
 	// -----------------------------------------------------------------------
 	// Classic checkout
 	// -----------------------------------------------------------------------
 
 	test( 'Classic: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
 		await setCheckoutPageId( request, BASE_URL, classicPageId );
-		await loginAsAdmin( page );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
 		await page.waitForLoadState( 'networkidle' );
@@ -154,7 +144,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 
 	test( 'Block: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
 		await setCheckoutPageId( request, BASE_URL, blockPageId );
-		await loginAsAdmin( page );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
 		await page.waitForLoadState( 'networkidle' );
@@ -182,7 +172,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう' );
 		}
 
-		await loginAsAdmin( page );
+		await login( page, BASE_URL );
 
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
 		await page.waitForLoadState( 'networkidle' );
@@ -220,7 +210,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう-block' );
 		}
 
-		await loginAsAdmin( page );
+		await login( page, BASE_URL );
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
 		await page.waitForLoadState( 'networkidle' );
 
@@ -250,7 +240,7 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう-block' );
 		}
 
-		await loginAsAdmin( page );
+		await login( page, BASE_URL );
 		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
 		await page.waitForLoadState( 'networkidle' );
 

--- a/tests/e2e/myaccount-view.spec.ts
+++ b/tests/e2e/myaccount-view.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * E2E tests: My Account address view page — yomigana deduplication
+ *
+ * Verifies that on the My Account address display page (/my-account/?edit-address),
+ * yomigana appears exactly once regardless of whether classic or block checkout
+ * is configured.
+ *
+ * Both classic and block checkout: yomigana must appear only via the JP-formatted
+ * address string (address_formats + formatted_address). WC Additional Fields API
+ * render_address_fields() must NOT output a duplicate below the formatted block.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import {
+	ADMIN_USER,
+	ADMIN_PASS,
+	setJp4wcSettings,
+	wpFetch,
+} from './utils/helpers';
+
+const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8891';
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+function getAuth(): string {
+	if ( process.env.WP_APP_PASSWORD ) {
+		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
+	}
+	const credFile = path.resolve( __dirname, '.auth/credentials.json' );
+	if ( fs.existsSync( credFile ) ) {
+		const creds = JSON.parse( fs.readFileSync( credFile, 'utf8' ) ) as { user: string; appPassword: string };
+		return Buffer.from( `${ creds.user }:${ creds.appPassword }` ).toString( 'base64' );
+	}
+	return Buffer.from( `${ ADMIN_USER }:${ ADMIN_PASS }` ).toString( 'base64' );
+}
+
+// ---------------------------------------------------------------------------
+// REST helpers
+// ---------------------------------------------------------------------------
+
+async function wcPut(
+	request: APIRequestContext,
+	endpoint: string,
+	body: object,
+): Promise<unknown> {
+	const res = await request.put( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: {
+			Authorization: `Basic ${ getAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: JSON.stringify( body ),
+	} );
+	return res.json();
+}
+
+async function wcGet(
+	request: APIRequestContext,
+	endpoint: string,
+): Promise<unknown> {
+	const res = await request.get( `${ BASE_URL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: { Authorization: `Basic ${ getAuth() }` },
+	} );
+	return res.json();
+}
+
+async function getCheckoutPageId( request: APIRequestContext ): Promise<string> {
+	const settings = ( await wcGet( request, 'settings/advanced' ) ) as { id: string; value: string }[];
+	return settings.find( ( s ) => s.id === 'woocommerce_checkout_page_id' )?.value ?? '';
+}
+
+async function setCheckoutPageId(
+	request: APIRequestContext,
+	pageId: string | number,
+): Promise<void> {
+	await wcPut( request, 'settings/advanced/woocommerce_checkout_page_id', {
+		value: String( pageId ),
+	} );
+}
+
+/** Set billing or shipping address for a WC customer (user ID). */
+async function setCustomerAddress(
+	request: APIRequestContext,
+	customerId: number,
+	type: 'billing' | 'shipping',
+	address: Record< string, string >,
+): Promise<void> {
+	await wcPut( request, `customers/${ customerId }`, { [ type ]: address } );
+}
+
+/**
+ * Set arbitrary usermeta via wp-env CLI (WP REST API doesn't expose unregistered meta keys).
+ * Uses the tests-cli container so it targets the test environment (port 8891).
+ */
+function setUserMetaCli( userId: number, key: string, value: string ): void {
+	execSync(
+		`npx wp-env run tests-cli wp user meta update ${ userId } "${ key }" "${ value }"`,
+		{ stdio: 'pipe' },
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Page content constants
+// ---------------------------------------------------------------------------
+
+const CLASSIC_CHECKOUT_CONTENT =
+	`<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->`;
+
+const BLOCK_CHECKOUT_CONTENT =
+	`<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} --><div class="wp-block-woocommerce-checkout is-loading"></div><!-- /wp:woocommerce/checkout -->`;
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+test.describe( 'My Account address view — yomigana deduplication', () => {
+	let originalCheckoutPageId: string;
+	let classicPageId: number;
+	let blockPageId: number;
+
+	test.beforeAll( async ( { request } ) => {
+		originalCheckoutPageId = await getCheckoutPageId( request );
+
+		await setJp4wcSettings( request, BASE_URL, { yomigana: '1' } );
+
+		// Seed a complete billing + shipping address for admin (customer ID 1) via WC REST API.
+		// Without a full address, WC shows "You have not set up this type of address yet"
+		// and render_address_fields is never invoked, making the duplicate test trivial.
+		const baseAddress = {
+			first_name: '太郎',
+			last_name: '山田',
+			address_1: 'どっかどっか１',
+			city: '加古川市',
+			state: 'JP28',
+			postcode: '675-0001',
+			country: 'JP',
+		};
+		await setCustomerAddress( request, 1, 'billing', { ...baseAddress, email: 'test@example.com', phone: '090-1234-5678' } );
+		await setCustomerAddress( request, 1, 'shipping', baseAddress );
+
+		// Seed yomigana usermeta via wp-cli (WC REST API does not expose these custom meta keys).
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう' );
+		}
+
+		const classicPage = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+			title: 'Classic Checkout (e2e view yomigana)',
+			status: 'publish',
+			content: CLASSIC_CHECKOUT_CONTENT,
+		} ) as { id: number };
+		classicPageId = classicPage.id;
+
+		const blockPage = await wpFetch( request, BASE_URL, 'pages', 'POST', {
+			title: 'Block Checkout (e2e view yomigana)',
+			status: 'publish',
+			content: BLOCK_CHECKOUT_CONTENT,
+		} ) as { id: number };
+		blockPageId = blockPage.id;
+	} );
+
+	test.afterAll( async ( { request } ) => {
+		if ( originalCheckoutPageId ) {
+			await setCheckoutPageId( request, originalCheckoutPageId );
+		}
+		for ( const id of [ classicPageId, blockPageId ] ) {
+			if ( id ) {
+				await wpFetch( request, BASE_URL, `pages/${ id }?force=true`, 'DELETE' );
+			}
+		}
+	} );
+
+	async function loginAsAdmin( page: import('@playwright/test').Page ): Promise<void> {
+		await page.goto( `${ BASE_URL }/wp-login.php` );
+		await page.fill( '#user_login', ADMIN_USER );
+		await page.fill( '#user_pass', ADMIN_PASS );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( /wp-admin/ );
+	}
+
+	// -----------------------------------------------------------------------
+	// Classic checkout
+	// -----------------------------------------------------------------------
+
+	test( 'Classic: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
+		await setCheckoutPageId( request, classicPageId );
+		await loginAsAdmin( page );
+
+		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
+		await page.waitForLoadState( 'networkidle' );
+
+		await page.screenshot( { path: 'test-results/classic-view-page.png', fullPage: true } );
+
+		// The formatted address must include yomigana (from JP format string).
+		await expect( page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' ) ).toContainText( 'やまだ' );
+
+		// WC's render_address_fields must NOT add a bare "Last Name ( Yomigana ): やまだ" line.
+		// If the duplicate is present, this label appears as <strong> text.
+		const wcApiLabels = page.locator( 'text="Last Name ( Yomigana )"' );
+		await expect( wcApiLabels ).toHaveCount( 0 );
+	} );
+
+	// -----------------------------------------------------------------------
+	// Block checkout — yomigana stored in classic meta keys
+	// -----------------------------------------------------------------------
+
+	test( 'Block: address view shows yomigana exactly once (no WC-API duplicate)', async ( { page, request } ) => {
+		await setCheckoutPageId( request, blockPageId );
+		await loginAsAdmin( page );
+
+		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
+		await page.waitForLoadState( 'networkidle' );
+
+		await page.screenshot( { path: 'test-results/block-view-page.png', fullPage: true } );
+
+		await expect( page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' ) ).toContainText( 'やまだ' );
+
+		const wcApiLabels = page.locator( 'text="Last Name ( Yomigana )"' );
+		await expect( wcApiLabels ).toHaveCount( 0 );
+	} );
+
+	// -----------------------------------------------------------------------
+	// Block checkout — yomigana stored only in WC Additional Fields API meta keys
+	// -----------------------------------------------------------------------
+
+	test( 'Block (WC API meta): address view shows yomigana from _wc_billing/jp4wc/ keys', async ( { page, request } ) => {
+		await setCheckoutPageId( request, blockPageId );
+
+		// Replace classic meta keys with WC Additional Fields API meta keys.
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, '' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, '' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, 'やまだ' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう' );
+		}
+
+		await loginAsAdmin( page );
+
+		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
+		await page.waitForLoadState( 'networkidle' );
+
+		await page.screenshot( { path: 'test-results/block-wc-api-meta-view-page.png', fullPage: true } );
+
+		// Yomigana must appear via the JP format string fallback (from block checkout meta keys).
+		await expect( page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' ) ).toContainText( 'やまだ' );
+
+		// No duplicate bare label line from WC render_address_fields.
+		const wcApiLabels = page.locator( 'text="Last Name ( Yomigana )"' );
+		await expect( wcApiLabels ).toHaveCount( 0 );
+
+		// Restore classic meta keys for subsequent tests.
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, '' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, '' );
+		}
+	} );
+} );

--- a/tests/e2e/myaccount-view.spec.ts
+++ b/tests/e2e/myaccount-view.spec.ts
@@ -204,4 +204,69 @@ test.describe( 'My Account address view — yomigana deduplication', () => {
 			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, '' );
 		}
 	} );
+
+	// -----------------------------------------------------------------------
+	// Priority: when both meta key sets are present, checkout type wins
+	// -----------------------------------------------------------------------
+
+	test( 'Block (both meta): block keys take priority over classic keys', async ( { page, request } ) => {
+		await setCheckoutPageId( request, BASE_URL, blockPageId );
+
+		// Set DIFFERENT values in each meta key set so we can tell which is displayed.
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ-classic' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう-classic' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, 'やまだ-block' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう-block' );
+		}
+
+		await loginAsAdmin( page );
+		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
+		await page.waitForLoadState( 'networkidle' );
+
+		await page.screenshot( { path: 'test-results/block-priority-view-page.png', fullPage: true } );
+
+		// Block checkout configured → block keys must win.
+		const content = page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' );
+		await expect( content ).toContainText( 'やまだ-block' );
+		await expect( content ).not.toContainText( 'やまだ-classic' );
+
+		// Restore.
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, '' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, '' );
+		}
+	} );
+
+	test( 'Classic (both meta): classic keys take priority over block keys', async ( { page, request } ) => {
+		await setCheckoutPageId( request, BASE_URL, classicPageId );
+
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ-classic' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう-classic' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, 'やまだ-block' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, 'たろう-block' );
+		}
+
+		await loginAsAdmin( page );
+		await page.goto( `${ BASE_URL }/my-account/?edit-address` );
+		await page.waitForLoadState( 'networkidle' );
+
+		await page.screenshot( { path: 'test-results/classic-priority-view-page.png', fullPage: true } );
+
+		// Classic checkout configured → classic keys must win.
+		const content = page.locator( '.woocommerce-address-fields, .woocommerce-MyAccount-content' );
+		await expect( content ).toContainText( 'やまだ-classic' );
+		await expect( content ).not.toContainText( 'やまだ-block' );
+
+		// Restore.
+		for ( const type of [ 'billing', 'shipping' ] ) {
+			setUserMetaCli( 1, `${ type }_yomigana_last_name`, 'やまだ' );
+			setUserMetaCli( 1, `${ type }_yomigana_first_name`, 'たろう' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_last_name`, '' );
+			setUserMetaCli( 1, `_wc_${ type }/jp4wc/yomigana_first_name`, '' );
+		}
+	} );
 } );

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -29,8 +29,8 @@ export async function wpFetch(
 export const ADMIN_USER = 'admin';
 export const ADMIN_PASS = 'password';
 
-/** Read the Application Password written by global-setup.ts */
-function getBasicAuth(): string {
+/** Read the Application Password written by global-setup.ts. Exported as getAuth for specs. */
+export function getBasicAuth(): string {
 	// Prefer env var (set by global-setup in the same process).
 	if ( process.env.WP_APP_PASSWORD ) {
 		return Buffer.from( `${ ADMIN_USER }:${ process.env.WP_APP_PASSWORD }` ).toString( 'base64' );
@@ -61,6 +61,66 @@ export async function login( page: Page, baseURL: string ): Promise<void> {
 // ---------------------------------------------------------------------------
 // WooCommerce REST API helpers
 // ---------------------------------------------------------------------------
+
+/** PUT to WC REST API /wc/v3/{endpoint}. */
+export async function wcPut(
+	request: APIRequestContext,
+	baseURL: string,
+	endpoint: string,
+	body: object,
+): Promise<unknown> {
+	const res = await request.put( `${ baseURL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: {
+			Authorization: `Basic ${ getBasicAuth() }`,
+			'Content-Type': 'application/json',
+		},
+		data: JSON.stringify( body ),
+	} );
+	return res.json();
+}
+
+/** GET from WC REST API /wc/v3/{endpoint}. */
+export async function wcGet(
+	request: APIRequestContext,
+	baseURL: string,
+	endpoint: string,
+): Promise<unknown> {
+	const res = await request.get( `${ baseURL }/wp-json/wc/v3/${ endpoint }`, {
+		headers: { Authorization: `Basic ${ getBasicAuth() }` },
+	} );
+	return res.json();
+}
+
+/** Get the current WC checkout page ID from WC settings. */
+export async function getCheckoutPageId(
+	request: APIRequestContext,
+	baseURL: string,
+): Promise<string> {
+	const settings = ( await wcGet( request, baseURL, 'settings/advanced' ) ) as { id: string; value: string }[];
+	return settings.find( ( s ) => s.id === 'woocommerce_checkout_page_id' )?.value ?? '';
+}
+
+/** Set the WC checkout page ID in WC settings. */
+export async function setCheckoutPageId(
+	request: APIRequestContext,
+	baseURL: string,
+	pageId: string | number,
+): Promise<void> {
+	await wcPut( request, baseURL, 'settings/advanced/woocommerce_checkout_page_id', {
+		value: String( pageId ),
+	} );
+}
+
+/** Set billing or shipping address for a WC customer by user ID. */
+export async function setCustomerAddress(
+	request: APIRequestContext,
+	baseURL: string,
+	customerId: number,
+	type: 'billing' | 'shipping',
+	address: Record< string, string >,
+): Promise<void> {
+	await wcPut( request, baseURL, `customers/${ customerId }`, { [ type ]: address } );
+}
 
 async function wcFetch(
 	request: APIRequestContext,

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -29,7 +29,7 @@ export async function wpFetch(
 export const ADMIN_USER = 'admin';
 export const ADMIN_PASS = 'password';
 
-/** Read the Application Password written by global-setup.ts. Exported as getAuth for specs. */
+/** Read the Application Password written by global-setup.ts. Used by wcGet, wcPut, and related helpers. */
 export function getBasicAuth(): string {
 	// Prefer env var (set by global-setup in the same process).
 	if ( process.env.WP_APP_PASSWORD ) {


### PR DESCRIPTION
## Summary

- WC's \`CheckoutFieldsFrontend::edit_address_fields()\` (priority 10) always injects \`_wc_{type}/jp4wc/*\` fields into the My Account address edit form via the \`woocommerce_address_to_edit\` filter. On classic-checkout sites (and FSE block-checkout sites where \`has_block()\` returns false), JP4WC's own \`{type}_yomigana_*\` fields are also present, causing **two yomigana rows** — one near the name field (correct position) and one near the email field with an incorrect \`name\` attribute (\`_wc_billing/jp4wc/yomigana_last_name\`).
- Reported: duplicate yomigana in My Account billing and shipping address edit forms since v2.9.4.

## Changes

Add \`remove_duplicate_yomigana_from_address_edit()\` at priority 20 on \`woocommerce_address_to_edit\`:
- When traditional \`{type}_yomigana_last_name\` fields are present (classic/FSE checkout), removes WC-added \`_wc_{type}/jp4wc/*\` entries → only one yomigana row shown in traditional position
- When traditional fields are absent (non-FSE block checkout where \`add_yomigana_fields()\` exits early), WC-added fields are kept as the sole display mechanism

Add 4 regression tests verifying: billing deduplication, shipping deduplication, block-checkout passthrough, and disabled-option passthrough.

## Test plan

- [ ] Classic checkout theme — My Account billing address edit: only ONE yomigana row near name field, no duplicate near email
- [ ] Classic checkout theme — My Account shipping address edit: same
- [ ] Block checkout (non-FSE theme) — My Account address edit: yomigana row appears via WC Additional Fields API only
- [ ] FSE block checkout theme — My Account address edit: only ONE yomigana row (traditional position)
- [ ] Yomigana option disabled — no yomigana rows in My Account address edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)