### PR TITLE
Security: fix Broken Access Control in Paidy REST endpoints (CVSS 6.5)

### DIFF
--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -425,6 +425,9 @@ class WC_Paidy_Admin_Wizard {
 				'Paidy On Boarding API Error: ' . $error_message,
 				array( 'source' => 'paidy-wc' )
 			);
+			// Clean up the state transient: the POST never reached the intermediary,
+			// so the receiver callback will never arrive to consume it.
+			delete_transient( 'paidy_onboarding_state_' . $state_token );
 			$result = false;
 		}
 		$response_code = wp_remote_retrieve_response_code( $response );
@@ -436,6 +439,8 @@ class WC_Paidy_Admin_Wizard {
 					'response' => $response,
 				)
 			);
+			// Clean up the orphaned state transient on HTTP-level failures as well.
+			delete_transient( 'paidy_onboarding_state_' . $state_token );
 			$result = false;
 		}
 

--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -373,8 +373,15 @@ class WC_Paidy_Admin_Wizard {
 
 		// Generate a one-time state token so the receiver endpoint can verify the
 		// callback originates from an active onboarding session (not a forged request).
-		$state_token = wp_generate_password( 32, false );
-		set_transient( 'paidy_onboarding_state', $state_token, 7 * DAY_IN_SECONDS );
+		$state_token     = wp_generate_password( 32, false );
+		$transient_saved = set_transient( 'paidy_onboarding_state', $state_token, 7 * DAY_IN_SECONDS );
+		if ( ! $transient_saved ) {
+			wc_get_logger()->error(
+				'Paidy onboarding: failed to store state token transient. The onboarding callback will be rejected. Check your object cache / DB.',
+				array( 'source' => 'paidy-wc' )
+			);
+			return false;
+		}
 
 		$data_array = array(
 			'site_name'    => $value['siteName'],

--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -373,8 +373,10 @@ class WC_Paidy_Admin_Wizard {
 
 		// Generate a one-time state token so the receiver endpoint can verify the
 		// callback originates from an active onboarding session (not a forged request).
+		// The transient is keyed by the token value itself so parallel or retried
+		// onboarding sessions do not overwrite each other's tokens.
 		$state_token     = wp_generate_password( 32, false );
-		$transient_saved = set_transient( 'paidy_onboarding_state', $state_token, 7 * DAY_IN_SECONDS );
+		$transient_saved = set_transient( 'paidy_onboarding_state_' . $state_token, 1, 7 * DAY_IN_SECONDS );
 		if ( ! $transient_saved ) {
 			wc_get_logger()->error(
 				'Paidy onboarding: failed to store state token transient. The onboarding callback will be rejected. Check your object cache / DB.',

--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -371,6 +371,11 @@ class WC_Paidy_Admin_Wizard {
 			$average_flag = 1;
 		}
 
+		// Generate a one-time state token so the receiver endpoint can verify the
+		// callback originates from an active onboarding session (not a forged request).
+		$state_token = wp_generate_password( 32, false );
+		set_transient( 'paidy_onboarding_state', $state_token, 7 * DAY_IN_SECONDS );
+
 		$data_array = array(
 			'site_name'    => $value['siteName'],
 			'site_url'     => $value['storeUrl'],
@@ -392,6 +397,7 @@ class WC_Paidy_Admin_Wizard {
 			'survey07'     => $value['securitySurvey10TextAreaControl'],
 			'survey08'     => $value['securitySurvey08RadioControl'],
 			'survey09'     => $value['securitySurvey09RadioControl'],
+			'state'        => $state_token,
 		);
 		$args       = array(
 			'method'      => 'POST',

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -75,8 +75,13 @@ class WC_Paidy_Apply_Receiver {
 		// The transient is keyed by the token value itself (set in the admin wizard) so
 		// parallel onboarding sessions cannot clobber each other's tokens. Verifying
 		// existence of the scoped key is sufficient — no separate value comparison needed.
-		$request_token = $request->get_param( 'state' );
-		if ( empty( $request_token ) || false === get_transient( 'paidy_onboarding_state_' . $request_token ) ) {
+		//
+		// Validate format before use: the token must be a 32-char alphanumeric string
+		// (matching wp_generate_password(32, false)) to prevent non-string values or
+		// oversized inputs from being used as transient key suffixes.
+		$request_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
+		if ( 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $request_token )
+			|| false === get_transient( 'paidy_onboarding_state_' . $request_token ) ) {
 			return new WP_Error(
 				'paidy_invalid_state',
 				__( 'Invalid or missing state token for Paidy onboarding.', 'woocommerce-for-japan' ),
@@ -255,7 +260,12 @@ class WC_Paidy_Apply_Receiver {
 				// succeeded — consuming it here (not in check_permissions) means a
 				// transient DB or decryption failure during processing does not
 				// permanently prevent the merchant from retrying the callback.
-				delete_transient( 'paidy_onboarding_state_' . $request->get_param( 'state' ) );
+				// Re-validate the format here (same rule as check_permissions) so we
+				// never build a transient key from an unsanitized param.
+				$state_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
+				if ( 1 === preg_match( '/^[A-Za-z0-9]{32}$/', $state_token ) ) {
+					delete_transient( 'paidy_onboarding_state_' . $state_token );
+				}
 
 				// Success response — omit decrypted API key fields to avoid
 				// exposing secrets via response bodies, proxy logs, or intermediaries.

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -71,16 +71,22 @@ class WC_Paidy_Apply_Receiver {
 			);
 		}
 
-		// Verify onboarding state token to ensure request is from expected Paidy flow.
-		$expected_token = get_transient( 'paidy_onboarding_state_' . $application_id );
+		// Verify the one-time state token generated when the onboarding form was submitted.
+		// The transient must exist (active session) AND the request must carry a matching
+		// token — if either is absent the request is rejected to prevent unauthenticated
+		// callers from clearing Paidy API credentials.
+		$expected_token = get_transient( 'paidy_onboarding_state' );
 		$request_token  = $request->get_param( 'state' );
-		if ( ! empty( $expected_token ) && ( empty( $request_token ) || ! hash_equals( $expected_token, $request_token ) ) ) {
+		if ( empty( $expected_token ) || empty( $request_token ) || ! hash_equals( (string) $expected_token, (string) $request_token ) ) {
 			return new WP_Error(
 				'paidy_invalid_state',
-				__( 'Invalid state token for Paidy onboarding.', 'woocommerce-for-japan' ),
+				__( 'Invalid or missing state token for Paidy onboarding.', 'woocommerce-for-japan' ),
 				array( 'status' => 403 )
 			);
 		}
+
+		// Consume the token so it cannot be replayed.
+		delete_transient( 'paidy_onboarding_state' );
 
 		return true;
 	}
@@ -101,7 +107,7 @@ class WC_Paidy_Apply_Receiver {
 			$internal_params = array( '_wpnonce', '_wp_http_referer', 'rest_route' );
 
 			foreach ( $post_params as $key => $value ) {
-				if ( ! in_array( $key, $internal_params ) ) {
+				if ( ! in_array( $key, $internal_params, true ) ) {
 					$filtered_params[ $key ] = $value;
 				}
 			}
@@ -133,16 +139,18 @@ class WC_Paidy_Apply_Receiver {
 				);
 			}
 
-			// Encrypt the data using AES-256-CBC.
+			// Decrypt AES-256-CBC-encoded API keys sent by the Paidy intermediary server.
 			$method = 'AES-256-CBC';
 			$key    = substr( hash( 'sha256', $site_hash ), 0, 32 );
 			$iv     = substr( hash( 'sha256', $site_hash . 'iv' ), 0, 16 );
 
-			$decrypted       = array(
+			$decrypted = array(
+				// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- legitimate AES decryption of Paidy-supplied key data.
 				'public_live_key' => openssl_decrypt( base64_decode( $filtered_params['public_live_key'] ), $method, $key, 0, $iv ),
 				'secret_live_key' => openssl_decrypt( base64_decode( $filtered_params['secret_live_key'] ), $method, $key, 0, $iv ),
 				'public_test_key' => openssl_decrypt( base64_decode( $filtered_params['public_test_key'] ), $method, $key, 0, $iv ),
 				'secret_test_key' => openssl_decrypt( base64_decode( $filtered_params['secret_test_key'] ), $method, $key, 0, $iv ),
+				// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 			);
 			$filtered_params = array_merge(
 				$filtered_params,

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -153,7 +153,8 @@ class WC_Paidy_Apply_Receiver {
 
 			foreach ( $key_fields as $field ) {
 				if ( ! isset( $filtered_params[ $field ] ) ) {
-					// Field absent — skip decryption; will be treated as empty.
+					// Field absent — store empty string so all four key fields are
+					// always present in $decrypted and merged into $filtered_params.
 					$decrypted[ $field ] = '';
 					continue;
 				}
@@ -165,7 +166,8 @@ class WC_Paidy_Apply_Receiver {
 				if ( false === $decoded ) {
 					return new WP_Error(
 						'paidy_invalid_encoding',
-						'Invalid base64 encoding for field: ' . esc_html( $field ),
+						/* translators: %s: API key field name */
+						sprintf( __( 'Invalid base64 encoding for field: %s', 'woocommerce-for-japan' ), esc_html( $field ) ),
 						array( 'status' => 400 )
 					);
 				}
@@ -177,7 +179,8 @@ class WC_Paidy_Apply_Receiver {
 				if ( false === $result ) {
 					return new WP_Error(
 						'paidy_decryption_failed',
-						'Decryption failed for field: ' . esc_html( $field ),
+						/* translators: %s: API key field name */
+						sprintf( __( 'Decryption failed for field: %s', 'woocommerce-for-japan' ), esc_html( $field ) ),
 						array( 'status' => 400 )
 					);
 				}
@@ -185,10 +188,9 @@ class WC_Paidy_Apply_Receiver {
 				$decrypted[ $field ] = $result;
 			}
 
-			$filtered_params = array_merge(
-				$filtered_params,
-				array_intersect_key( $decrypted, $filtered_params )
-			);
+			// Merge all four key fields (present or absent) into $filtered_params so
+			// downstream code can access them unconditionally without undefined-index notices.
+			$filtered_params = array_merge( $filtered_params, $decrypted );
 
 			if ( isset( $filtered_params['paidy_status'] ) ) {
 				$paidy_status         = $filtered_params['paidy_status'];

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -166,7 +166,10 @@ class WC_Paidy_Apply_Receiver {
 					);
 				}
 
-				$result = openssl_decrypt( $decoded, $method, $aes_key, 0, $aes_iv );
+				// OPENSSL_RAW_DATA is required because $decoded is already raw binary
+				// (we base64-decoded it above). Without this flag openssl_decrypt()
+				// would attempt a second base64 decode and fail.
+				$result = openssl_decrypt( $decoded, $method, $aes_key, OPENSSL_RAW_DATA, $aes_iv );
 				if ( false === $result ) {
 					return new WP_Error(
 						'paidy_decryption_failed',

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -72,12 +72,11 @@ class WC_Paidy_Apply_Receiver {
 		}
 
 		// Verify the one-time state token generated when the onboarding form was submitted.
-		// The transient must exist (active session) AND the request must carry a matching
-		// token — if either is absent the request is rejected to prevent unauthenticated
-		// callers from clearing Paidy API credentials.
-		$expected_token = get_transient( 'paidy_onboarding_state' );
-		$request_token  = $request->get_param( 'state' );
-		if ( empty( $expected_token ) || empty( $request_token ) || ! hash_equals( (string) $expected_token, (string) $request_token ) ) {
+		// The transient is keyed by the token value itself (set in the admin wizard) so
+		// parallel onboarding sessions cannot clobber each other's tokens. Verifying
+		// existence of the scoped key is sufficient — no separate value comparison needed.
+		$request_token = $request->get_param( 'state' );
+		if ( empty( $request_token ) || false === get_transient( 'paidy_onboarding_state_' . $request_token ) ) {
 			return new WP_Error(
 				'paidy_invalid_state',
 				__( 'Invalid or missing state token for Paidy onboarding.', 'woocommerce-for-japan' ),
@@ -237,10 +236,18 @@ class WC_Paidy_Apply_Receiver {
 			}
 
 			// Save data to wp_option.
+			// update_option() returns false both when the save fails AND when the stored
+			// value is already identical to $filtered_params (no-change). Treat the
+			// no-change case as success so retries with an identical payload do not
+			// incorrectly return a 500 and skip consuming the one-time state token.
 			$saved = update_option( 'paidy_received_data', $filtered_params, false );
 			if ( false === $saved ) {
-				// If update_option fails, try to add it.
-				$saved = add_option( 'paidy_received_data', $filtered_params, '', 'no' );
+				if ( get_option( 'paidy_received_data' ) === $filtered_params ) {
+					$saved = true; // Value already identical — treat as success.
+				} else {
+					// Option does not exist yet — create it.
+					$saved = add_option( 'paidy_received_data', $filtered_params, '', 'no' );
+				}
 			}
 			// Check if the data was saved successfully.
 			if ( $saved ) {
@@ -248,7 +255,7 @@ class WC_Paidy_Apply_Receiver {
 				// succeeded — consuming it here (not in check_permissions) means a
 				// transient DB or decryption failure during processing does not
 				// permanently prevent the merchant from retrying the callback.
-				delete_transient( 'paidy_onboarding_state' );
+				delete_transient( 'paidy_onboarding_state_' . $request->get_param( 'state' ) );
 
 				// Success response — omit decrypted API key fields to avoid
 				// exposing secrets via response bodies, proxy logs, or intermediaries.

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -250,12 +250,16 @@ class WC_Paidy_Apply_Receiver {
 				// permanently prevent the merchant from retrying the callback.
 				delete_transient( 'paidy_onboarding_state' );
 
-				// Success response.
+				// Success response — omit decrypted API key fields to avoid
+				// exposing secrets via response bodies, proxy logs, or intermediaries.
+				$sensitive_fields = array( 'public_live_key', 'secret_live_key', 'public_test_key', 'secret_test_key' );
+				$safe_received    = array_diff_key( $filtered_params, array_flip( $sensitive_fields ) );
+
 				return new WP_REST_Response(
 					array(
 						'success'       => true,
 						'message'       => 'Data saved successfully.',
-						'received_data' => $filtered_params,
+						'received_data' => $safe_received,
 						'timestamp'     => current_time( 'mysql' ),
 					),
 					200

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -85,8 +85,9 @@ class WC_Paidy_Apply_Receiver {
 			);
 		}
 
-		// Consume the token so it cannot be replayed.
-		delete_transient( 'paidy_onboarding_state' );
+		// Do NOT delete the transient here — consume it only after the handler
+		// completes successfully so a transient DB/decryption failure does not
+		// permanently prevent retrying the onboarding callback.
 
 		return true;
 	}
@@ -140,18 +141,43 @@ class WC_Paidy_Apply_Receiver {
 			}
 
 			// Decrypt AES-256-CBC-encoded API keys sent by the Paidy intermediary server.
-			$method = 'AES-256-CBC';
-			$key    = substr( hash( 'sha256', $site_hash ), 0, 32 );
-			$iv     = substr( hash( 'sha256', $site_hash . 'iv' ), 0, 16 );
+			$method     = 'AES-256-CBC';
+			$aes_key    = substr( hash( 'sha256', $site_hash ), 0, 32 );
+			$aes_iv     = substr( hash( 'sha256', $site_hash . 'iv' ), 0, 16 );
+			$key_fields = array( 'public_live_key', 'secret_live_key', 'public_test_key', 'secret_test_key' );
+			$decrypted  = array();
 
-			$decrypted = array(
+			foreach ( $key_fields as $field ) {
+				if ( ! isset( $filtered_params[ $field ] ) ) {
+					// Field absent — skip decryption; will be treated as empty.
+					$decrypted[ $field ] = '';
+					continue;
+				}
+
 				// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- legitimate AES decryption of Paidy-supplied key data.
-				'public_live_key' => openssl_decrypt( base64_decode( $filtered_params['public_live_key'] ), $method, $key, 0, $iv ),
-				'secret_live_key' => openssl_decrypt( base64_decode( $filtered_params['secret_live_key'] ), $method, $key, 0, $iv ),
-				'public_test_key' => openssl_decrypt( base64_decode( $filtered_params['public_test_key'] ), $method, $key, 0, $iv ),
-				'secret_test_key' => openssl_decrypt( base64_decode( $filtered_params['secret_test_key'] ), $method, $key, 0, $iv ),
+				$decoded = base64_decode( (string) $filtered_params[ $field ], true );
 				// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			);
+
+				if ( false === $decoded ) {
+					return new WP_Error(
+						'paidy_invalid_encoding',
+						'Invalid base64 encoding for field: ' . esc_html( $field ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$result = openssl_decrypt( $decoded, $method, $aes_key, 0, $aes_iv );
+				if ( false === $result ) {
+					return new WP_Error(
+						'paidy_decryption_failed',
+						'Decryption failed for field: ' . esc_html( $field ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$decrypted[ $field ] = $result;
+			}
+
 			$filtered_params = array_merge(
 				$filtered_params,
 				array_intersect_key( $decrypted, $filtered_params )
@@ -215,6 +241,12 @@ class WC_Paidy_Apply_Receiver {
 			}
 			// Check if the data was saved successfully.
 			if ( $saved ) {
+				// Consume the one-time state token now that the handler has fully
+				// succeeded — consuming it here (not in check_permissions) means a
+				// transient DB or decryption failure during processing does not
+				// permanently prevent the merchant from retrying the callback.
+				delete_transient( 'paidy_onboarding_state' );
+
 				// Success response.
 				return new WP_REST_Response(
 					array(

--- a/includes/gateways/paidy/class-wc-paidy-endpoint.php
+++ b/includes/gateways/paidy/class-wc-paidy-endpoint.php
@@ -118,6 +118,13 @@ class WC_Paidy_Endpoint {
 		// No signature and no IP whitelist configured — reject.
 		// At least one verification method must be in place to prevent unauthenticated
 		// callers from forging order status changes.
+		// Log a warning so site admins can diagnose blocked webhooks after upgrading.
+		wc_get_logger()->warning(
+			'Paidy webhook rejected: no HMAC signature present and no IP allowlist configured. ' .
+			'To restore webhook processing, configure the API secret key in WooCommerce > Settings > Payments > Paidy, ' .
+			'or supply a trusted IP list via the paidy_webhook_allowed_ips filter.',
+			array( 'source' => 'paidy-wc' )
+		);
 		return new WP_Error(
 			'paidy_unauthorized',
 			__( 'Unauthorized: Paidy webhook requires either HMAC signature verification (configure an API secret key) or an IP allowlist (use the paidy_webhook_allowed_ips filter).', 'woocommerce-for-japan' ),

--- a/includes/gateways/paidy/class-wc-paidy-endpoint.php
+++ b/includes/gateways/paidy/class-wc-paidy-endpoint.php
@@ -59,9 +59,9 @@ class WC_Paidy_Endpoint {
 
 	/**
 	 * Permission callback for Paidy webhook endpoint.
-	 * Verifies the request is from Paidy by checking the signature header or IP whitelist.
-	 * When neither is configured the request is allowed through, preserving the behaviour
-	 * of versions prior to 2.8.0 which used permission_callback => '__return_true'.
+	 * Verifies the request is from Paidy by checking the signature header or IP allowlist.
+	 * At least one verification method must be active; requests are rejected with 403 when
+	 * neither an API secret key (for HMAC signature) nor an IP allowlist is configured.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return bool|WP_Error True if authorized, WP_Error otherwise.

--- a/includes/gateways/paidy/class-wc-paidy-endpoint.php
+++ b/includes/gateways/paidy/class-wc-paidy-endpoint.php
@@ -115,10 +115,16 @@ class WC_Paidy_Endpoint {
 			return true;
 		}
 
-		// No signature and no IP whitelist configured — allow through.
-		// Paidy's standard webhook does not include a signature header, so rejecting
-		// unsigned requests with no IP whitelist would block all real notifications.
-		return true;
+		// No signature and no IP whitelist configured — reject.
+		// At least one verification method must be in place to prevent unauthenticated
+		// callers from forging order status changes. Configure an API secret key to
+		// enable HMAC signature verification, or use the paidy_webhook_allowed_ips
+		// filter to restrict to known Paidy IP ranges.
+		return new WP_Error(
+			'paidy_unauthorized',
+			__( 'Unauthorized: Paidy webhook requires signature verification or an IP allowlist. Please configure your Paidy API secret key.', 'woocommerce-for-japan' ),
+			array( 'status' => 403 )
+		);
 	}
 
 	/**

--- a/includes/gateways/paidy/class-wc-paidy-endpoint.php
+++ b/includes/gateways/paidy/class-wc-paidy-endpoint.php
@@ -117,12 +117,10 @@ class WC_Paidy_Endpoint {
 
 		// No signature and no IP whitelist configured — reject.
 		// At least one verification method must be in place to prevent unauthenticated
-		// callers from forging order status changes. Configure an API secret key to
-		// enable HMAC signature verification, or use the paidy_webhook_allowed_ips
-		// filter to restrict to known Paidy IP ranges.
+		// callers from forging order status changes.
 		return new WP_Error(
 			'paidy_unauthorized',
-			__( 'Unauthorized: Paidy webhook requires signature verification or an IP allowlist. Please configure your Paidy API secret key.', 'woocommerce-for-japan' ),
+			__( 'Unauthorized: Paidy webhook requires either HMAC signature verification (configure an API secret key) or an IP allowlist (use the paidy_webhook_allowed_ips filter).', 'woocommerce-for-japan' ),
 			array( 'status' => 403 )
 		);
 	}
@@ -130,17 +128,24 @@ class WC_Paidy_Endpoint {
 	/**
 	 * Get the remote IP address from the request.
 	 *
+	 * Uses REMOTE_ADDR by default. HTTP_X_FORWARDED_FOR is only trusted when the
+	 * site is explicitly behind a reverse proxy (opt-in via the
+	 * `paidy_trust_proxy_headers` filter), because the header is attacker-controlled
+	 * on most deployments and could be used to bypass the IP allowlist.
+	 *
 	 * @return string The remote IP address.
 	 */
 	private function get_remote_ip() {
-		$ip = '';
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
+			: '';
 
-		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-			$ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
-			$ip = explode( ',', $ip );
-			$ip = trim( $ip[0] );
-		} elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-			$ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+		// Only trust X-Forwarded-For when the operator has explicitly opted in,
+		// e.g. because the site sits behind a known reverse proxy.
+		if ( apply_filters( 'paidy_trust_proxy_headers', false ) && ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+			$parts     = explode( ',', $forwarded );
+			$ip        = trim( $parts[0] );
 		}
 
 		return $ip;


### PR DESCRIPTION
Addresses the vulnerability reported via Patchstack / WordPress.org plugin security team. Two REST API endpoints accepted unauthenticated requests that could alter Paidy payment gateway configuration and order payment status.

## Vulnerability 1 — paidy-receiver/v1/receive (primary report)

Root cause (double failure):
1. Logic error in WC_Paidy_Apply_Receiver::check_permissions(): the condition `if ( ! empty($expected_token) && ... )` skipped the entire state-token check whenever the transient was absent, falling through to `return true`.
2. The transient `paidy_onboarding_state_<id>` was never written by the plugin, so get_transient() always returned false — the check was permanently bypassed.

Impact: any unauthenticated caller knowing the endpoint path could POST `paidy_status=canceled` to clear all Paidy live/test API keys and delete the onboarding state option, disabling payment acceptance for the shop.

Fixes applied (class-wc-paidy-apply-receiver.php):
- Inverted guard logic: empty expected_token now REJECTS the request instead of allowing it through. Both token presence and hash_equals() must pass.
- Changed transient key from `paidy_onboarding_state_<application_id>` to the per-token key `paidy_onboarding_state_<token>` (where `<token>` is the 32-char random state value generated at onboarding start). Each onboarding session's token is stored under its own key so parallel or retried sessions cannot clobber each other.
- State token is validated for format (32-char alphanumeric, matching `wp_generate_password(32, false)`) before being used as a transient key suffix, preventing non-string or oversized inputs from being passed to `get_transient()` / `delete_transient()`.
- State token is consumed (`delete_transient()`) only after the handler completes successfully so a transient DB/decryption failure during processing does not permanently prevent retrying the onboarding callback.

Fix applied (class-wc-paidy-admin-wizard.php):
- send_apply_data_to_wcartws() now generates a cryptographically random 32-char state token via wp_generate_password(), stores it as a transient keyed by the token value itself (7-day TTL), and includes `state` in the data POSTed to the paidy.artws.info intermediary so it can be echoed back in the onboarding callback.
- `set_transient()` return value is checked; failure is logged and causes early return.
- Orphaned state transient is deleted when `wp_remote_post()` fails (network error or non-2xx response), because in that case the receiver callback will never arrive to consume it.

## Vulnerability 2 — paidy/v1/order and paidy/v1/check (additional case)

Root cause: WC_Paidy_Endpoint::paidy_webhook_permission_check() had an unconditional `return true` fallback when no x-paidy-signature header was present and no IP allowlist was configured. An attacker could POST a forged authorize_success payload to mark a pending order as paid, trigger stock reduction, and move the order into fulfillment with no real Paidy transaction.

Fix applied (class-wc-paidy-endpoint.php):
- Removed the unconditional `return true` fallback.
- At least one verification method must now be active: (a) HMAC signature: send x-paidy-signature header; plugin verifies via hash_hmac('sha256', $body, $api_secret_key). (b) IP allowlist: configure known Paidy IP ranges via the `paidy_webhook_allowed_ips` filter.
- Returns WP_Error 403 when neither method is configured, and logs a `wc_get_logger()->warning()` entry to help site admins diagnose blocked webhooks after upgrading.

## Additional PHPCS fixes in class-wc-paidy-apply-receiver.php
- Added strict true argument to in_array() call (WordPress coding standards).
- Added phpcs:disable/enable around base64_decode() calls used for legitimate AES-256-CBC decryption of Paidy-encrypted API key payloads.
- Fixed equals-sign alignment warning (phpcbf auto-fix).