### PR TITLE
Fix Paidy webhook regression and duplicate payment note

### DIFF
--- a/includes/gateways/paidy/class-wc-gateway-paidy.php
+++ b/includes/gateways/paidy/class-wc-gateway-paidy.php
@@ -735,7 +735,8 @@ class WC_Gateway_Paidy extends WC_Payment_Gateway {
 	public function thankyou_completed( $order_id ) {
 		$order          = wc_get_order( $order_id );
 		$current_status = $order->get_status();
-		if ( 'pending' === $current_status || 'cancelled' === $current_status ) {
+		// Idempotency: skip if payment_complete() was already called (transaction_id already set).
+		if ( ( 'pending' === $current_status || 'cancelled' === $current_status ) && empty( $order->get_transaction_id() ) ) {
 			// Reduce stock levels.
 			wc_reduce_stock_levels( $order_id );
 			$order->payment_complete( $_GET['transaction_id'] );// phpcs:ignore

--- a/includes/gateways/paidy/class-wc-gateway-paidy.php
+++ b/includes/gateways/paidy/class-wc-gateway-paidy.php
@@ -733,15 +733,19 @@ class WC_Gateway_Paidy extends WC_Payment_Gateway {
 	 * @param string $order_id Order ID.
 	 */
 	public function thankyou_completed( $order_id ) {
-		$order          = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
+		}
 		$current_status = $order->get_status();
 		// Idempotency: skip if payment_complete() was already called (transaction_id already set).
 		if ( ( 'pending' === $current_status || 'cancelled' === $current_status ) && empty( $order->get_transaction_id() ) ) {
 			// Reduce stock levels.
 			wc_reduce_stock_levels( $order_id );
-			$order->payment_complete( $_GET['transaction_id'] );// phpcs:ignore
+			$transaction_id = isset( $_GET['transaction_id'] ) ? sanitize_text_field( wp_unslash( $_GET['transaction_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order->payment_complete( $transaction_id );
 			$message  = __( 'Paidy Payment succeeds to authorize and move to thank you page. Get data is following.', 'woocommerce-for-japan' ) . "\n";
-			$message .= $this->jp4wc_framework->jp4wc_array_to_message( $_GET ); // phpcs:ignore
+			$message .= $this->jp4wc_framework->jp4wc_array_to_message( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->jp4wc_framework->jp4wc_debug_log( $message, $this->debug, 'paidy-wc' );
 		}
 	}

--- a/includes/gateways/paidy/class-wc-paidy-endpoint.php
+++ b/includes/gateways/paidy/class-wc-paidy-endpoint.php
@@ -211,6 +211,10 @@ class WC_Paidy_Endpoint {
 				$enable_authorize_success_statuses = apply_filters( 'paidy_endpoint_enable_authorize_statuses', array( 'pending', 'cancelled' ), $order );
 
 				if ( 'authorize_success' === $main_data['status'] && in_array( $status, $enable_authorize_success_statuses, true ) ) {
+					// Idempotency: skip if payment_complete() was already called (transaction_id already set).
+					if ( ! empty( $order->get_transaction_id() ) ) {
+						return new WP_REST_Response( $main_data, 200 );
+					}
 					// Reduce stock levels.
 					wc_reduce_stock_levels( $main_data['order_ref'] );
 					if ( isset( $main_data['payment_id'] ) ) {


### PR DESCRIPTION
## Summary

- **Webhook permission regression fix**: v2.9.13のセキュリティ修正でWebhookが全件403を返すリグレッションが発生していた。APIシークレットキーもIPホワイトリストも未設定の場合は2.9.13以前の動作（allow through）に戻し、デバッグログで通知するよう修正。
- **重複注文メモの修正**: Webhookとフロントエンドのサンキューページリダイレクトがほぼ同時に到着した場合、両方が `pending` 状態で `payment_complete()` を呼び出し、注文メモ「Paidy 翌月払い（コンビニ/銀行） での支払い (pay_xxx)」が2回書き込まれる問題を修正。
- **冪等性チェック追加**: `payment_complete()` 呼び出し前に `get_transaction_id()` の有無を確認し、すでに設定済みならスキップする処理を Webhook ハンドラー・`thankyou_completed()` の両方に追加。

## Changes

- `class-wc-paidy-endpoint.php`: 検証未設定時はallow throughに変更 + `authorize_success`処理に冪等性チェック追加
- `class-wc-gateway-paidy.php`: `thankyou_completed()` に冪等性チェック追加

## Test plan

- [x] Paidyテスト環境でブロックチェックアウトから決済完了まで通ることを確認
- [x] 注文メモが1件のみ書き込まれることを確認（重複なし）
- [x] Webhookがサンキューページより先に届くケースと後に届くケースの両方で動作確認済み
- [x] APIシークレットキー未設定でもWebhookが正常に処理されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)