### PR TITLE
ci: add Create plugin zip step and fix .distignore exclusions

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,24 +15,36 @@
 /src
 /docs
 /tests
+/test-results
 /promotion-json
 
 # Files
+.DS_Store
 .wp-env.json
 .gitattributes
 .distignore
 .gitignore
 .phpcs.xml.dist
 .phpunit.xml.dist
+.phpunit.result.cache
 phpunit.xml.dist
+playwright.config.ts
+tsconfig.e2e.json
 composer.json
 composer.lock
 package-lock.json
 package.json
 webpack.config.js
+wordfence-vendor.txt
 LICENSE
 README.md
 CLAUDE.md
 SECURITY-FIX-PAIDY.md
 SHORTCODE-CHECKOUT-VALIDATION-REPORT.md
+
+# Source files (compiled output is sufficient for distribution)
+*.scss
+
+# Temporary files
+temp-editor.json
 

--- a/.github/workflows/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
+++ b/.github/workflows/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
@@ -9,13 +9,45 @@ jobs:
     tag:
         name: New tag
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        env:
+            FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         steps:
             - name: Checkout code
-              uses: actions/checkout@master
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20.x'
+                  cache: 'npm'
+
+            - name: Install dependencies & build
+              run: |
+                  npm ci
+                  npm run build
+
+            - name: Get version from tag
+              id: version
+              run: echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+            - name: Extract changelog for this version
+              id: changelog
+              run: |
+                  VERSION="${{ steps.version.outputs.VERSION }}"
+                  BODY=$(awk "/^= ${VERSION} /{found=1; next} found && /^= [0-9]+\.[0-9]+/{exit} found && NF{print}" readme.txt)
+                  {
+                    echo "BODY<<EOF"
+                    echo "$BODY"
+                    echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Install SVN ( Subversion )
               run: |
                   sudo apt-get update
                   sudo apt-get install subversion
+
             - name: Remove PayPal gateway from SVN trunk
               env:
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
@@ -34,20 +66,41 @@ jobs:
                   else
                       echo "PayPal gateway not found in SVN trunk. Skipping."
                   fi
+
             - name: Remove nested .git directories from vendor packages
               run: find . -mindepth 2 -name '.git' -type d -exec rm -rf '{}' + 2>/dev/null || true
+
+            - name: Create plugin zip
+              run: |
+                  PLUGIN_SLUG="woocommerce-for-japan"
+                  VERSION="${{ steps.version.outputs.VERSION }}"
+                  DEST="${PLUGIN_SLUG}-${VERSION}"
+
+                  mkdir -p "/tmp/${DEST}/${PLUGIN_SLUG}"
+                  rsync -a \
+                    --exclude-from='.distignore' \
+                    . "/tmp/${DEST}/${PLUGIN_SLUG}/"
+
+                  cd "/tmp/${DEST}"
+                  zip -r "${PLUGIN_SLUG}-${VERSION}.zip" "${PLUGIN_SLUG}/"
+
+                  mv "${PLUGIN_SLUG}-${VERSION}.zip" "$GITHUB_WORKSPACE/"
+
             - name: WordPress Plugin Deploy
               id: deploy
               uses: 10up/action-wordpress-plugin-deploy@stable
               with:
-                  generate-zip: true
+                  generate-zip: false
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
                   SLUG: 'woocommerce-for-japan'
-            - name: Create GitHub release
-              uses: softprops/action-gh-release@v1
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
               with:
-                  files: ${{github.workspace}}/${{ github.event.repository.name }}.zip
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  name: ${{ github.ref_name }}
+                  tag_name: ${{ github.ref_name }}
+                  body: ${{ steps.changelog.outputs.BODY }}
+                  generate_release_notes: true
+                  files: woocommerce-for-japan-${{ steps.version.outputs.VERSION }}.zip

--- a/.github/workflows/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
+++ b/.github/workflows/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
@@ -102,5 +102,4 @@ jobs:
                   name: ${{ github.ref_name }}
                   tag_name: ${{ github.ref_name }}
                   body: ${{ steps.changelog.outputs.BODY }}
-                  generate_release_notes: true
                   files: woocommerce-for-japan-${{ steps.version.outputs.VERSION }}.zip


### PR DESCRIPTION
## Summary

- **リリースワークフローの改善**: `Create plugin zip` ステップを追加し、payjp-for-wc と同様のリリースフローに統一。
- **`.distignore` の修正**: 配布ZIPに含まれてはいけないファイルが漏れていたため追加。

## Changes

### ワークフロー (`deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml`)
- Node.js セットアップ + `npm run build` を追加（ビルド済みJSをZIPに含める）
- バージョン・changelog自動抽出ステップを追加
- `Create plugin zip` ステップ追加: rsync + `.distignore` で `woocommerce-for-japan-{version}.zip` を生成
- `softprops/action-gh-release@v2` に更新（リリース名・changebodyを自動設定）
- `actions/checkout@v4` に更新、`permissions: contents: write` 追加
- 10up deploy の `generate-zip: false`（独自ZIPを使用するため）

### `.distignore`
以下のファイルが配布ZIPに含まれていたため除外を追加:

| 追加した除外 | 理由 |
|---|---|
| `.DS_Store` | macOSメタデータ |
| `.phpunit.result.cache` | PHPUnitキャッシュ |
| `/test-results/` | Playwrightのスクリーンショット等 |
| `playwright.config.ts` / `tsconfig.e2e.json` | e2eテスト設定 |
| `wordfence-vendor.txt` | 配布不要 |
| `temp-editor.json` | i18n一時ファイル |
| `*.scss` | CSSソースファイル（コンパイル済みで十分） |

## Test plan
- [ ] タグプッシュ時にワークフローが正常に動作することを確認
- [ ] 生成されるZIPに不要ファイルが含まれないことを確認
- [ ] WordPress.org SVNデプロイが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)