### PR TITLE
fix: COD2手数料テーブルを全削除して保存すると元のデータが復活する問題を修正

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod2.php
+++ b/includes/gateways/cod/class-wc-gateway-cod2.php
@@ -474,22 +474,27 @@ class WC_Gateway_COD2 extends WC_Payment_Gateway {
 	public function save_cod2_fee_details() {
 		$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
 
-		if ( ! isset( $_POST['cod2_fee'] ) || ! isset( $_POST['cod2_max'] ) || ! wp_verify_nonce( $nonce, 'woocommerce-settings' ) ) {
+		// Bail only on nonce failure to prevent CSRF; an absent cod2_fee key
+		// means all rows were deleted and we intentionally save an empty array.
+		if ( ! wp_verify_nonce( $nonce, 'woocommerce-settings' ) ) {
 			return;
 		}
 
-		$fees      = array();
-		$cod2_fees = wc_clean( array_map( 'sanitize_text_field', wp_unslash( $_POST['cod2_fee'] ) ) );
-		$cod2_maxs = wc_clean( array_map( 'sanitize_text_field', wp_unslash( $_POST['cod2_max'] ) ) );
+		$fees = array();
 
-		foreach ( $cod2_fees as $i => $fee ) {
-			if ( ! isset( $cod2_maxs[ $i ] ) ) {
-				continue;
+		if ( isset( $_POST['cod2_fee'] ) && isset( $_POST['cod2_max'] ) ) {
+			$cod2_fees = wc_clean( array_map( 'sanitize_text_field', wp_unslash( $_POST['cod2_fee'] ) ) );
+			$cod2_maxs = wc_clean( array_map( 'sanitize_text_field', wp_unslash( $_POST['cod2_max'] ) ) );
+
+			foreach ( $cod2_fees as $i => $fee ) {
+				if ( ! isset( $cod2_maxs[ $i ] ) ) {
+					continue;
+				}
+				$fees[] = array(
+					'cod_fee' => $fee,
+					'cod_max' => $cod2_maxs[ $i ],
+				);
 			}
-			$fees[] = array(
-				'cod_fee' => $fee,
-				'cod_max' => $cod2_maxs[ $i ],
-			);
 		}
 
 		if ( isset( $_POST['jp4wc_tax_class_for_cod2'] ) ) {


### PR DESCRIPTION
## 問題

WC_Gateway_COD2の「Charge amount of details」テーブルで全行を削除して保存すると、保存されずに前のデータが復活してしまう。

## 原因

`save_cod2_fee_details()` で nonce チェックとフィールド存在チェックを同一条件にしていたため、全行削除時（`cod2_fee` / `cod2_max` が POST に存在しない）に早期リターンしてしまい `update_option` が実行されなかった。

```php
// 修正前 — cod2_fee が無いと早期リターンし保存されない
if ( ! isset( $_POST['cod2_fee'] ) || ! isset( $_POST['cod2_max'] ) || ! wp_verify_nonce(...) ) {
    return;
}
update_option( 'woocommerce_cod2_fees', $fees ); // 全削除時は到達しない
```

## 修正

nonce チェックのみで早期リターンし（CSRF対策）、フィールドの有無は「行データがあるか」の判定にのみ使用する。全行削除時は空配列を保存する。

```php
// 修正後 — nonce 失敗時のみ早期リターン
if ( ! wp_verify_nonce( $nonce, 'woocommerce-settings' ) ) {
    return;
}
// cod2_fee がなければ空配列のまま update_option を実行 → 正しく空になる
if ( isset( $_POST['cod2_fee'] ) && isset( $_POST['cod2_max'] ) ) {
    // 行データがある場合のみ配列を構築
}
update_option( 'woocommerce_cod2_fees', $fees );
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)