### PR TITLE
fix: remove pk_test_ default value injection in Paidy wizard redirect

### DIFF
--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -552,7 +552,7 @@ class WC_Paidy_Admin_Wizard {
 
 	/**
 	 * Handles redirect when wizard=false parameter is present.
-	 * Updates test_api_public_key with pk_test_ prefix and redirects to Paidy settings page.
+	 * Redirects to Paidy settings page.
 	 */
 	public function paidy_handle_wizard_false_redirect() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -578,28 +578,6 @@ class WC_Paidy_Admin_Wizard {
 		// Check user capability.
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
-		}
-
-		// Update test_api_public_key with pk_test_ prefix if not already present.
-		$paidy_settings = get_option( 'woocommerce_' . $this->id . '_settings' );
-
-		if ( ! is_array( $paidy_settings ) ) {
-			$paidy_settings = array();
-		}
-
-		// If test_api_public_key exists, add pk_test_ prefix if not already present.
-		if ( isset( $paidy_settings['test_api_public_key'] ) ) {
-			$current_key = $paidy_settings['test_api_public_key'];
-
-			// Add prefix if not already present.
-			if ( 0 !== strpos( $current_key, 'pk_test_' ) ) {
-				$paidy_settings['test_api_public_key'] = 'pk_test_' . $current_key;
-				update_option( 'woocommerce_' . $this->id . '_settings', $paidy_settings );
-			}
-		} else {
-			// If test_api_public_key does not exist, set it to pk_test_.
-			$paidy_settings['test_api_public_key'] = 'pk_test_';
-			update_option( 'woocommerce_' . $this->id . '_settings', $paidy_settings );
 		}
 
 		// Redirect to Paidy settings page (remove wizard=false parameter).


### PR DESCRIPTION
## 問題

Paidy ウィザードの `wizard=false` リダイレクト処理（`paidy_handle_wizard_false_redirect()`）が、設定画面への遷移時に `test_api_public_key` オプションを書き換えていました。

- キーが未設定の場合 → `pk_test_` をセット
- キーが設定済みで `pk_test_` プレフィックスがない場合 → 先頭に `pk_test_` を追記

これにより、ユーザーが設定画面を開くと「API公開キー（テスト）」フィールドに `pk_test_` が初期値として表示されたり、保存済みのキーが書き換えられるという問題が発生していました。

## 対応

`test_api_public_key` を書き換えるブロック（23行）を丸ごと削除しました。  
このメソッドはリダイレクト処理のみを担当し、キーの管理はユーザーに委ねます。

## Test plan

- [ ] Paidy 設定ウィザードを `wizard=false` パラメータ付きで開き、設定画面へリダイレクトされることを確認
- [ ] 「API公開キー（テスト）」フィールドに `pk_test_` が自動入力されないことを確認
- [ ] 既存のテスト API キーが書き換えられないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)