### PR TITLE
fix: suppress duplicate yomigana on My Account view-order page

### DIFF
--- a/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
+++ b/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
@@ -377,10 +377,13 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 	 * order-received (thank-you) page and the My Account view-order page, so yomigana
 	 * suppression is needed on both.
 	 *
+	 * The result is passed through the jp4wc_is_order_display_page filter so that
+	 * tests can override it without needing to manipulate WP query vars.
+	 *
 	 * @return bool
 	 */
 	private function is_order_display_page() {
-		return is_order_received_page() || is_wc_endpoint_url( 'view-order' );
+		return (bool) apply_filters( 'jp4wc_is_order_display_page', is_order_received_page() || is_wc_endpoint_url( 'view-order' ) );
 	}
 
 	/**

--- a/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
+++ b/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
@@ -20,6 +20,19 @@ if ( ! interface_exists( 'Automattic\WooCommerce\Blocks\Integrations\Integration
 class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 
 	/**
+	 * Whether start_order_address_fields_buffer() actually opened an output buffer
+	 * that filter_order_address_fields_buffer() still needs to close.
+	 *
+	 * Tracked instead of re-evaluating is_order_display_page() at priority 11, since
+	 * a jp4wc_is_order_display_page filter callback could otherwise return a different
+	 * value between priority 9 and priority 11 and leave a buffer open (or unintentionally
+	 * clean an unrelated buffer).
+	 *
+	 * @var bool
+	 */
+	private $order_address_buffer_open = false;
+
+	/**
 	 * The name of the integration.
 	 *
 	 * @return string
@@ -307,6 +320,7 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 	public function start_order_address_fields_buffer( $address_type, $order ) {
 		if ( $this->is_order_display_page() ) {
 			ob_start();
+			$this->order_address_buffer_open = true;
 		}
 	}
 
@@ -317,13 +331,19 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 	 * show_in_order_confirmation. We strip the yomigana <dt>/<dd> pairs here
 	 * because they are already embedded in the formatted address block above.
 	 *
+	 * Gated on $order_address_buffer_open (set by start_order_address_fields_buffer())
+	 * rather than re-checking is_order_display_page(), so a filter callback that changes
+	 * its answer between priority 9 and 11 can't leave a buffer open or clean one we
+	 * never opened.
+	 *
 	 * @param string   $address_type billing or shipping.
 	 * @param WC_Order $order Order object.
 	 */
 	public function filter_order_address_fields_buffer( $address_type, $order ) {
-		if ( ! $this->is_order_display_page() ) {
+		if ( ! $this->order_address_buffer_open ) {
 			return;
 		}
+		$this->order_address_buffer_open = false;
 
 		$output = ob_get_clean();
 		if ( empty( $output ) ) {

--- a/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
+++ b/includes/blocks/class-jp4wc-yomigana-blocks-integration.php
@@ -148,11 +148,11 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 		// Register yomigana last name field (applies to both billing and shipping).
 		// Note: Field order is controlled via JavaScript (see checkout-blocks-jp4wc.js).
 		$field_config = array(
-			'id'                       => 'jp4wc/yomigana_last_name',
-			'label'                    => __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ),
-			'location'                 => 'address',
-			'type'                     => 'text',
-			'required'                 => $is_required,
+			'id'                         => 'jp4wc/yomigana_last_name',
+			'label'                      => __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ),
+			'location'                   => 'address',
+			'type'                       => 'text',
+			'required'                   => $is_required,
 			'show_in_order_confirmation' => false,
 		);
 
@@ -168,11 +168,11 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 		// Register yomigana first name field (applies to both billing and shipping).
 		// Note: Field order is controlled via JavaScript (see checkout-blocks-jp4wc.js).
 		$field_config = array(
-			'id'                       => 'jp4wc/yomigana_first_name',
-			'label'                    => __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ),
-			'location'                 => 'address',
-			'type'                     => 'text',
-			'required'                 => $is_required,
+			'id'                         => 'jp4wc/yomigana_first_name',
+			'label'                      => __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ),
+			'location'                   => 'address',
+			'type'                       => 'text',
+			'required'                   => $is_required,
 			'show_in_order_confirmation' => false,
 		);
 
@@ -299,13 +299,13 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 
 	/**
 	 * Start output buffer before WooCommerce renders address additional fields (priority 9).
-	 * Only active on the order-received page.
+	 * Active on the order-received (thank-you) page and My Account view-order page.
 	 *
 	 * @param string   $address_type billing or shipping.
 	 * @param WC_Order $order Order object.
 	 */
 	public function start_order_address_fields_buffer( $address_type, $order ) {
-		if ( is_order_received_page() ) {
+		if ( $this->is_order_display_page() ) {
 			ob_start();
 		}
 	}
@@ -321,7 +321,7 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 	 * @param WC_Order $order Order object.
 	 */
 	public function filter_order_address_fields_buffer( $address_type, $order ) {
-		if ( ! is_order_received_page() ) {
+		if ( ! $this->is_order_display_page() ) {
 			return;
 		}
 
@@ -368,6 +368,19 @@ class JP4WC_Yomigana_Blocks_Integration implements IntegrationInterface {
 		// Remove empty wrapper if all additional fields were stripped.
 		$block_content = preg_replace( '/<dl[^>]*>\s*<\/dl>/', '', $block_content );
 		return $block_content;
+	}
+
+	/**
+	 * Return true on pages that render order address fields via the classic template.
+	 *
+	 * WooCommerce fires woocommerce_order_details_after_customer_address on both the
+	 * order-received (thank-you) page and the My Account view-order page, so yomigana
+	 * suppression is needed on both.
+	 *
+	 * @return bool
+	 */
+	private function is_order_display_page() {
+		return is_order_received_page() || is_wc_endpoint_url( 'view-order' );
 	}
 
 	/**

--- a/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
+++ b/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
@@ -341,4 +341,77 @@ class JP4WC_Yomigana_Blocks_Validation_Test extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( '<dl', $result );
 	}
+
+	// ------------------------------------------------------------------
+	// start_order_address_fields_buffer / filter_order_address_fields_buffer
+	// ------------------------------------------------------------------
+
+	/**
+	 * Output buffer is started when jp4wc_is_order_display_page returns true
+	 * (covers both order-received and My Account view-order pages).
+	 */
+	public function test_buffer_starts_on_order_display_page() {
+		add_filter( 'jp4wc_is_order_display_page', '__return_true' );
+
+		$level_before = ob_get_level();
+		$this->integration->start_order_address_fields_buffer( 'billing', null );
+		$level_after = ob_get_level();
+
+		if ( ob_get_level() > $level_before ) {
+			ob_end_clean();
+		}
+
+		remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
+
+		$this->assertGreaterThan( $level_before, $level_after, 'ob_start() should be called on order display pages' );
+	}
+
+	/**
+	 * Output buffer is NOT started on pages other than order display pages.
+	 */
+	public function test_buffer_does_not_start_outside_order_display_page() {
+		add_filter( 'jp4wc_is_order_display_page', '__return_false' );
+
+		$level_before = ob_get_level();
+		$this->integration->start_order_address_fields_buffer( 'billing', null );
+
+		remove_filter( 'jp4wc_is_order_display_page', '__return_false' );
+
+		$this->assertSame( $level_before, ob_get_level(), 'ob_start() should not be called outside order display pages' );
+	}
+
+	/**
+	 * Yomigana dt/dd pairs are stripped from buffered output on order display pages.
+	 *
+	 * Simulates the priority-9/10/11 sequence:
+	 *   9  → start_order_address_fields_buffer() opens a buffer
+	 *   10 → WooCommerce renders additional fields (yomigana) into that buffer
+	 *   11 → filter_order_address_fields_buffer() consumes the buffer and echoes filtered HTML
+	 */
+	public function test_filter_strips_yomigana_from_buffer_on_order_display_page() {
+		add_filter( 'jp4wc_is_order_display_page', '__return_true' );
+
+		$label_last  = esc_html( __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ) );
+		$label_first = esc_html( __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ) );
+
+		// Outer buffer captures whatever filter_order_address_fields_buffer echoes.
+		ob_start();
+
+		// Priority 9: open inner buffer (via start_order_address_fields_buffer).
+		$this->integration->start_order_address_fields_buffer( 'billing', null );
+
+		// Priority 10: WooCommerce renders yomigana + other fields into the inner buffer.
+		echo "<dl><dt>{$label_last}</dt><dd>タナカ</dd><dt>{$label_first}</dt><dd>ショウヘイ</dd><dt>City</dt><dd>Tokyo</dd></dl>";
+
+		// Priority 11: consume inner buffer, strip yomigana, echo result to outer buffer.
+		$this->integration->filter_order_address_fields_buffer( 'billing', null );
+
+		$output = ob_get_clean();
+
+		remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
+
+		$this->assertStringNotContainsString( $label_last, $output, 'Last name yomigana dt/dd should be stripped' );
+		$this->assertStringNotContainsString( $label_first, $output, 'First name yomigana dt/dd should be stripped' );
+		$this->assertStringContainsString( 'Tokyo', $output, 'Non-yomigana entries should remain' );
+	}
 }

--- a/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
+++ b/tests/Unit/test-jp4wc-yomigana-blocks-validation.php
@@ -352,18 +352,20 @@ class JP4WC_Yomigana_Blocks_Validation_Test extends WP_UnitTestCase {
 	 */
 	public function test_buffer_starts_on_order_display_page() {
 		add_filter( 'jp4wc_is_order_display_page', '__return_true' );
-
 		$level_before = ob_get_level();
-		$this->integration->start_order_address_fields_buffer( 'billing', null );
-		$level_after = ob_get_level();
+		$level_after  = $level_before;
 
-		if ( ob_get_level() > $level_before ) {
-			ob_end_clean();
+		try {
+			$this->integration->start_order_address_fields_buffer( 'billing', null );
+			$level_after = ob_get_level();
+
+			$this->assertGreaterThan( $level_before, $level_after, 'ob_start() should be called on order display pages' );
+		} finally {
+			while ( ob_get_level() > $level_before ) {
+				ob_end_clean();
+			}
+			remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
 		}
-
-		remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
-
-		$this->assertGreaterThan( $level_before, $level_after, 'ob_start() should be called on order display pages' );
 	}
 
 	/**
@@ -371,13 +373,18 @@ class JP4WC_Yomigana_Blocks_Validation_Test extends WP_UnitTestCase {
 	 */
 	public function test_buffer_does_not_start_outside_order_display_page() {
 		add_filter( 'jp4wc_is_order_display_page', '__return_false' );
-
 		$level_before = ob_get_level();
-		$this->integration->start_order_address_fields_buffer( 'billing', null );
 
-		remove_filter( 'jp4wc_is_order_display_page', '__return_false' );
+		try {
+			$this->integration->start_order_address_fields_buffer( 'billing', null );
 
-		$this->assertSame( $level_before, ob_get_level(), 'ob_start() should not be called outside order display pages' );
+			$this->assertSame( $level_before, ob_get_level(), 'ob_start() should not be called outside order display pages' );
+		} finally {
+			while ( ob_get_level() > $level_before ) {
+				ob_end_clean();
+			}
+			remove_filter( 'jp4wc_is_order_display_page', '__return_false' );
+		}
 	}
 
 	/**
@@ -390,28 +397,35 @@ class JP4WC_Yomigana_Blocks_Validation_Test extends WP_UnitTestCase {
 	 */
 	public function test_filter_strips_yomigana_from_buffer_on_order_display_page() {
 		add_filter( 'jp4wc_is_order_display_page', '__return_true' );
+		$level_before = ob_get_level();
+		$output       = '';
 
-		$label_last  = esc_html( __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ) );
-		$label_first = esc_html( __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ) );
+		try {
+			$label_last  = esc_html( __( 'Last Name ( Yomigana )', 'woocommerce-for-japan' ) );
+			$label_first = esc_html( __( 'First Name ( Yomigana )', 'woocommerce-for-japan' ) );
 
-		// Outer buffer captures whatever filter_order_address_fields_buffer echoes.
-		ob_start();
+			// Outer buffer captures whatever filter_order_address_fields_buffer echoes.
+			ob_start();
 
-		// Priority 9: open inner buffer (via start_order_address_fields_buffer).
-		$this->integration->start_order_address_fields_buffer( 'billing', null );
+			// Priority 9: open inner buffer (via start_order_address_fields_buffer).
+			$this->integration->start_order_address_fields_buffer( 'billing', null );
 
-		// Priority 10: WooCommerce renders yomigana + other fields into the inner buffer.
-		echo "<dl><dt>{$label_last}</dt><dd>タナカ</dd><dt>{$label_first}</dt><dd>ショウヘイ</dd><dt>City</dt><dd>Tokyo</dd></dl>";
+			// Priority 10: WooCommerce renders yomigana + other fields into the inner buffer.
+			echo "<dl><dt>{$label_last}</dt><dd>タナカ</dd><dt>{$label_first}</dt><dd>ショウヘイ</dd><dt>City</dt><dd>Tokyo</dd></dl>";
 
-		// Priority 11: consume inner buffer, strip yomigana, echo result to outer buffer.
-		$this->integration->filter_order_address_fields_buffer( 'billing', null );
+			// Priority 11: consume inner buffer, strip yomigana, echo result to outer buffer.
+			$this->integration->filter_order_address_fields_buffer( 'billing', null );
 
-		$output = ob_get_clean();
+			$output = ob_get_clean();
 
-		remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
-
-		$this->assertStringNotContainsString( $label_last, $output, 'Last name yomigana dt/dd should be stripped' );
-		$this->assertStringNotContainsString( $label_first, $output, 'First name yomigana dt/dd should be stripped' );
-		$this->assertStringContainsString( 'Tokyo', $output, 'Non-yomigana entries should remain' );
+			$this->assertStringNotContainsString( $label_last, $output, 'Last name yomigana dt/dd should be stripped' );
+			$this->assertStringNotContainsString( $label_first, $output, 'First name yomigana dt/dd should be stripped' );
+			$this->assertStringContainsString( 'Tokyo', $output, 'Non-yomigana entries should remain' );
+		} finally {
+			while ( ob_get_level() > $level_before ) {
+				ob_end_clean();
+			}
+			remove_filter( 'jp4wc_is_order_display_page', '__return_true' );
+		}
 	}
 }


### PR DESCRIPTION
## 問題

マイアカウントの注文詳細ページ（`/my-account/view-order/{id}`）で読み仮名が二重に表示される。

- 住所フォーマット内（氏名の下）に読み仮名が表示される ← 正常
- さらに `<dl>` リストとして `Last Name ( Yomigana )` / `First Name ( Yomigana )` が別途表示される ← 重複

Closes #196
Ref: https://wordpress.org/support/topic/%e3%83%9e%e3%82%a4%e3%82%a2%e3%82%ab%e3%82%a6%e3%83%b3%e3%83%88%e8%a9%b3%e7%b4%b0%e3%83%bb%e6%b3%a8%e6%96%87%e8%a9%b3%e7%b4%b0%e3%81%ae%e8%aa%ad%e3%81%bf%e4%bb%ae%e5%90%8d%e3%81%ab%e3%81%a4%e3%81%84/

## 根本原因

`woocommerce_order_details_after_customer_address` アクションは注文完了ページ（`is_order_received_page()`）だけでなく、マイアカウントの注文詳細ページでも発火する。

しかし、重複排除のための出力バッファが `is_order_received_page()` のみをチェックしており、注文詳細ページでは WooCommerce の `CheckoutFieldsFrontend::render_order_address_fields()`（priority 10）がフィルターなしで動作していた。

## 修正内容

`is_order_display_page()` プライベートヘルパーを追加し、注文完了ページと注文詳細ページの両方を対象にする。

```php
private function is_order_display_page() {
    return is_order_received_page() || is_wc_endpoint_url( 'view-order' );
}
```

`start_order_address_fields_buffer()` と `filter_order_address_fields_buffer()` の条件をこのヘルパーに置き換えることで、両ページで読み仮名の重複表示が抑制される。

## Test plan

- [x] マイアカウント → 注文詳細（`/my-account/view-order/{id}`）を開き、読み仮名が住所フォーマット内にのみ表示されることを確認（`<dl>` リストとして重複しないこと）
- [x] 注文完了ページ（`/order-received/`）でも同様に重複しないことを確認（既存動作の維持）
- [x] 読み仮名設定が無効の場合は何も表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)