### PR TITLE
fix: persist Paidy onboarding state token beyond transient TTL

### DIFF
--- a/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
+++ b/includes/gateways/paidy/class-wc-paidy-admin-wizard.php
@@ -373,13 +373,15 @@ class WC_Paidy_Admin_Wizard {
 
 		// Generate a one-time state token so the receiver endpoint can verify the
 		// callback originates from an active onboarding session (not a forged request).
-		// The transient is keyed by the token value itself so parallel or retried
-		// onboarding sessions do not overwrite each other's tokens.
-		$state_token     = wp_generate_password( 32, false );
-		$transient_saved = set_transient( 'paidy_onboarding_state_' . $state_token, 1, 2 * DAY_IN_SECONDS );
-		if ( ! $transient_saved ) {
+		// Tokens are stored keyed by their own value so parallel or retried
+		// onboarding sessions do not overwrite each other's tokens. Storage is a
+		// non-autoloaded option (not a transient) because the Paidy review can take
+		// weeks and the callback must still verify when it finally arrives.
+		$state_token = wp_generate_password( 32, false );
+		$state_saved = WC_Paidy_Apply_Receiver::store_state_token( $state_token );
+		if ( ! $state_saved ) {
 			wc_get_logger()->error(
-				'Paidy onboarding: failed to store state token transient. The onboarding callback will be rejected. Check your object cache / DB.',
+				'Paidy onboarding: failed to store state token option. The onboarding callback will be rejected. Check your DB.',
 				array( 'source' => 'paidy-wc' )
 			);
 			return false;
@@ -425,9 +427,9 @@ class WC_Paidy_Admin_Wizard {
 				'Paidy On Boarding API Error: ' . $error_message,
 				array( 'source' => 'paidy-wc' )
 			);
-			// Clean up the state transient: the POST never reached the intermediary,
+			// Clean up the state token: the POST never reached the intermediary,
 			// so the receiver callback will never arrive to consume it.
-			delete_transient( 'paidy_onboarding_state_' . $state_token );
+			WC_Paidy_Apply_Receiver::consume_state_token( $state_token );
 			$result = false;
 		}
 		$response_code = wp_remote_retrieve_response_code( $response );
@@ -439,8 +441,8 @@ class WC_Paidy_Admin_Wizard {
 					'response' => $response,
 				)
 			);
-			// Clean up the orphaned state transient on HTTP-level failures as well.
-			delete_transient( 'paidy_onboarding_state_' . $state_token );
+			// Clean up the orphaned state token on HTTP-level failures as well.
+			WC_Paidy_Apply_Receiver::consume_state_token( $state_token );
 			$result = false;
 		}
 

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -21,10 +21,125 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Paidy_Apply_Receiver {
 
 	/**
+	 * Option name that stores active onboarding state tokens.
+	 *
+	 * Stored as a non-autoloaded option holding array( token => issued UNIX time ).
+	 * Options survive object-cache evictions and have no TTL, unlike transients —
+	 * the Paidy review takes days to weeks, far longer than any safe transient TTL.
+	 */
+	const STATE_OPTION_NAME = 'paidy_onboarding_states';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Get the lifetime of an onboarding state token in seconds.
+	 *
+	 * @return int TTL in seconds.
+	 */
+	public static function get_state_token_ttl() {
+		/**
+		 * Filters the lifetime of a Paidy onboarding state token.
+		 *
+		 * The token must outlive the Paidy merchant review, which can take
+		 * several weeks between application and the key-delivery callback.
+		 *
+		 * @param int $ttl Lifetime in seconds. Default 90 days.
+		 */
+		return (int) apply_filters( 'wc4jp_paidy_onboarding_state_ttl', 90 * DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Store a one-time onboarding state token.
+	 *
+	 * Expired entries are pruned on every store so no cron cleanup is needed.
+	 *
+	 * @param string $token 32-char alphanumeric state token.
+	 * @return bool True if the token was persisted, false otherwise.
+	 */
+	public static function store_state_token( $token ) {
+		if ( ! is_string( $token ) || 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $token ) ) {
+			return false;
+		}
+
+		$states = get_option( self::STATE_OPTION_NAME, array() );
+		if ( ! is_array( $states ) ) {
+			$states = array();
+		}
+
+		// Prune expired entries while we are here.
+		$ttl = self::get_state_token_ttl();
+		$now = time();
+		foreach ( $states as $stored_token => $issued_at ) {
+			if ( ! is_int( $issued_at ) || ( $now - $issued_at ) > $ttl ) {
+				unset( $states[ $stored_token ] );
+			}
+		}
+
+		$states[ $token ] = $now;
+		update_option( self::STATE_OPTION_NAME, $states, false );
+
+		// Re-read to verify the token actually persisted — update_option()
+		// returns false on a no-change write, so its return value alone
+		// cannot distinguish failure from an identical existing value.
+		$saved = get_option( self::STATE_OPTION_NAME, array() );
+
+		return is_array( $saved ) && isset( $saved[ $token ] );
+	}
+
+	/**
+	 * Verify an onboarding state token exists and has not expired.
+	 *
+	 * @param string $token 32-char alphanumeric state token.
+	 * @return bool True if the token is valid.
+	 */
+	public static function verify_state_token( $token ) {
+		if ( ! is_string( $token ) || 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $token ) ) {
+			return false;
+		}
+
+		$states = get_option( self::STATE_OPTION_NAME, array() );
+		if ( is_array( $states ) && isset( $states[ $token ] ) ) {
+			$issued_at = $states[ $token ];
+			if ( is_int( $issued_at ) && ( time() - $issued_at ) <= self::get_state_token_ttl() ) {
+				return true;
+			}
+		}
+
+		// Legacy fallback: tokens issued by older plugin versions were stored as
+		// transients. Keep accepting them so an in-flight application submitted
+		// before the update still succeeds. TODO: remove after 2-3 releases.
+		if ( false !== get_transient( 'paidy_onboarding_state_' . $token ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Consume (delete) an onboarding state token so it cannot be reused.
+	 *
+	 * @param string $token 32-char alphanumeric state token.
+	 * @return void
+	 */
+	public static function consume_state_token( $token ) {
+		if ( ! is_string( $token ) || 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $token ) ) {
+			return;
+		}
+
+		$states = get_option( self::STATE_OPTION_NAME, array() );
+		if ( is_array( $states ) && isset( $states[ $token ] ) ) {
+			unset( $states[ $token ] );
+			update_option( self::STATE_OPTION_NAME, $states, false );
+		}
+
+		// Also clear the legacy transient variant. Remove together with the
+		// legacy fallback in verify_state_token().
+		delete_transient( 'paidy_onboarding_state_' . $token );
 	}
 
 	/**
@@ -72,16 +187,16 @@ class WC_Paidy_Apply_Receiver {
 		}
 
 		// Verify the one-time state token generated when the onboarding form was submitted.
-		// The transient is keyed by the token value itself (set in the admin wizard) so
+		// Tokens are stored keyed by their own value (set in the admin wizard) so
 		// parallel onboarding sessions cannot clobber each other's tokens. Verifying
 		// existence of the scoped key is sufficient — no separate value comparison needed.
 		//
 		// Validate format before use: the token must be a 32-char alphanumeric string
 		// (matching wp_generate_password(32, false)) to prevent non-string values or
-		// oversized inputs from being used as transient key suffixes.
+		// oversized inputs from being used as storage key suffixes.
 		$request_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
 		if ( 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $request_token )
-			|| false === get_transient( 'paidy_onboarding_state_' . $request_token ) ) {
+			|| ! self::verify_state_token( $request_token ) ) {
 			return new WP_Error(
 				'paidy_invalid_state',
 				__( 'Invalid or missing state token for Paidy onboarding.', 'woocommerce-for-japan' ),
@@ -89,7 +204,7 @@ class WC_Paidy_Apply_Receiver {
 			);
 		}
 
-		// Do NOT delete the transient here — consume it only after the handler
+		// Do NOT consume the token here — consume it only after the handler
 		// completes successfully so a transient DB/decryption failure does not
 		// permanently prevent retrying the onboarding callback.
 
@@ -281,10 +396,10 @@ class WC_Paidy_Apply_Receiver {
 				// transient DB or decryption failure during processing does not
 				// permanently prevent the merchant from retrying the callback.
 				// Re-validate the format here (same rule as check_permissions) so we
-				// never build a transient key from an unsanitized param.
+				// never build a storage key from an unsanitized param.
 				$state_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
 				if ( 1 === preg_match( '/^[A-Za-z0-9]{32}$/', $state_token ) ) {
-					delete_transient( 'paidy_onboarding_state_' . $state_token );
+					self::consume_state_token( $state_token );
 				}
 
 				// Success response — omit decrypted API key fields to avoid

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -82,7 +82,10 @@ class WC_Paidy_Apply_Receiver {
 	/**
 	 * Verify an onboarding state token exists and has not expired.
 	 *
-	 * @param string $token 32-char alphanumeric state token.
+	 * Accepts raw request input: anything but a 32-char alphanumeric string is
+	 * rejected before any storage key is built.
+	 *
+	 * @param mixed $token 32-char alphanumeric state token.
 	 * @return bool True if the token is valid.
 	 */
 	public static function verify_state_token( $token ) {
@@ -112,7 +115,10 @@ class WC_Paidy_Apply_Receiver {
 	/**
 	 * Consume (delete) an onboarding state token so it cannot be reused.
 	 *
-	 * @param string $token 32-char alphanumeric state token.
+	 * Accepts raw request input: anything but a 32-char alphanumeric string is
+	 * rejected before any storage key is built.
+	 *
+	 * @param mixed $token 32-char alphanumeric state token.
 	 * @return void
 	 */
 	public static function consume_state_token( $token ) {
@@ -139,8 +145,9 @@ class WC_Paidy_Apply_Receiver {
 
 		// Token options are non-autoloaded and keyed by a random token value,
 		// so there is no core API to enumerate them — a direct LIKE query is
-		// required. esc_like() escapes the underscores so the pattern cannot
-		// match the legacy `_transient_paidy_onboarding_state_*` rows.
+		// required. esc_like() makes the underscores match literally instead
+		// of acting as single-character LIKE wildcards, so the pattern cannot
+		// accidentally match other, similarly named option rows.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
@@ -212,12 +219,10 @@ class WC_Paidy_Apply_Receiver {
 		// parallel onboarding sessions cannot clobber each other's tokens. Verifying
 		// existence of the scoped key is sufficient — no separate value comparison needed.
 		//
-		// Validate format before use: the token must be a 32-char alphanumeric string
-		// (matching wp_generate_password(32, false)) to prevent non-string values or
-		// oversized inputs from being used as storage key suffixes.
-		$request_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
-		if ( 1 !== preg_match( '/^[A-Za-z0-9]{32}$/', $request_token )
-			|| ! self::verify_state_token( $request_token ) ) {
+		// verify_state_token() validates the format internally (32-char alphanumeric,
+		// matching wp_generate_password(32, false)) before building any storage key,
+		// so non-string values or oversized inputs are rejected there.
+		if ( ! self::verify_state_token( $request->get_param( 'state' ) ) ) {
 			return new WP_Error(
 				'paidy_invalid_state',
 				__( 'Invalid or missing state token for Paidy onboarding.', 'woocommerce-for-japan' ),
@@ -416,12 +421,10 @@ class WC_Paidy_Apply_Receiver {
 				// succeeded — consuming it here (not in check_permissions) means a
 				// transient DB or decryption failure during processing does not
 				// permanently prevent the merchant from retrying the callback.
-				// Re-validate the format here (same rule as check_permissions) so we
-				// never build a storage key from an unsanitized param.
-				$state_token = is_string( $request->get_param( 'state' ) ) ? $request->get_param( 'state' ) : '';
-				if ( 1 === preg_match( '/^[A-Za-z0-9]{32}$/', $state_token ) ) {
-					self::consume_state_token( $state_token );
-				}
+				// consume_state_token() validates the format internally (same rule
+				// as verify_state_token) so it never builds a storage key from an
+				// unsanitized param.
+				self::consume_state_token( $request->get_param( 'state' ) );
 
 				// Success response — omit decrypted API key fields to avoid
 				// exposing secrets via response bodies, proxy logs, or intermediaries.

--- a/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
+++ b/includes/gateways/paidy/class-wc-paidy-apply-receiver.php
@@ -21,13 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Paidy_Apply_Receiver {
 
 	/**
-	 * Option name that stores active onboarding state tokens.
+	 * Prefix for the options that store active onboarding state tokens.
 	 *
-	 * Stored as a non-autoloaded option holding array( token => issued UNIX time ).
+	 * Each token is stored as its own non-autoloaded option (prefix + token,
+	 * value = issued UNIX time). One row per token means concurrent onboarding
+	 * sessions insert separate rows and cannot overwrite each other — a single
+	 * shared array option would lose tokens to read-modify-write races.
 	 * Options survive object-cache evictions and have no TTL, unlike transients —
 	 * the Paidy review takes days to weeks, far longer than any safe transient TTL.
 	 */
-	const STATE_OPTION_NAME = 'paidy_onboarding_states';
+	const STATE_OPTION_PREFIX = 'paidy_onboarding_state_';
 
 	/**
 	 * Constructor.
@@ -66,29 +69,14 @@ class WC_Paidy_Apply_Receiver {
 			return false;
 		}
 
-		$states = get_option( self::STATE_OPTION_NAME, array() );
-		if ( ! is_array( $states ) ) {
-			$states = array();
-		}
+		self::prune_expired_state_tokens();
 
-		// Prune expired entries while we are here.
-		$ttl = self::get_state_token_ttl();
-		$now = time();
-		foreach ( $states as $stored_token => $issued_at ) {
-			if ( ! is_int( $issued_at ) || ( $now - $issued_at ) > $ttl ) {
-				unset( $states[ $stored_token ] );
-			}
-		}
-
-		$states[ $token ] = $now;
-		update_option( self::STATE_OPTION_NAME, $states, false );
+		update_option( self::STATE_OPTION_PREFIX . $token, time(), false );
 
 		// Re-read to verify the token actually persisted — update_option()
 		// returns false on a no-change write, so its return value alone
 		// cannot distinguish failure from an identical existing value.
-		$saved = get_option( self::STATE_OPTION_NAME, array() );
-
-		return is_array( $saved ) && isset( $saved[ $token ] );
+		return is_numeric( get_option( self::STATE_OPTION_PREFIX . $token ) );
 	}
 
 	/**
@@ -102,18 +90,19 @@ class WC_Paidy_Apply_Receiver {
 			return false;
 		}
 
-		$states = get_option( self::STATE_OPTION_NAME, array() );
-		if ( is_array( $states ) && isset( $states[ $token ] ) ) {
-			$issued_at = $states[ $token ];
-			if ( is_int( $issued_at ) && ( time() - $issued_at ) <= self::get_state_token_ttl() ) {
-				return true;
-			}
+		// is_numeric (not is_int): scalar options round-trip through the DB as
+		// numeric strings on requests other than the one that stored them.
+		$issued_at = get_option( self::STATE_OPTION_PREFIX . $token );
+		if ( is_numeric( $issued_at ) && ( time() - (int) $issued_at ) <= self::get_state_token_ttl() ) {
+			return true;
 		}
 
 		// Legacy fallback: tokens issued by older plugin versions were stored as
-		// transients. Keep accepting them so an in-flight application submitted
-		// before the update still succeeds. TODO: remove after 2-3 releases.
-		if ( false !== get_transient( 'paidy_onboarding_state_' . $token ) ) {
+		// transients under the same key (transients live in separate, prefixed
+		// option rows, so there is no collision). Keep accepting them so an
+		// in-flight application submitted before the update still succeeds.
+		// TODO: remove after 2-3 releases.
+		if ( false !== get_transient( self::STATE_OPTION_PREFIX . $token ) ) {
 			return true;
 		}
 
@@ -131,15 +120,47 @@ class WC_Paidy_Apply_Receiver {
 			return;
 		}
 
-		$states = get_option( self::STATE_OPTION_NAME, array() );
-		if ( is_array( $states ) && isset( $states[ $token ] ) ) {
-			unset( $states[ $token ] );
-			update_option( self::STATE_OPTION_NAME, $states, false );
-		}
+		delete_option( self::STATE_OPTION_PREFIX . $token );
 
 		// Also clear the legacy transient variant. Remove together with the
 		// legacy fallback in verify_state_token().
-		delete_transient( 'paidy_onboarding_state_' . $token );
+		delete_transient( self::STATE_OPTION_PREFIX . $token );
+	}
+
+	/**
+	 * Delete state token options that are past their TTL or hold invalid values.
+	 *
+	 * Runs on every store_state_token() call so no cron cleanup is needed.
+	 *
+	 * @return void
+	 */
+	private static function prune_expired_state_tokens() {
+		global $wpdb;
+
+		// Token options are non-autoloaded and keyed by a random token value,
+		// so there is no core API to enumerate them — a direct LIKE query is
+		// required. esc_like() escapes the underscores so the pattern cannot
+		// match the legacy `_transient_paidy_onboarding_state_*` rows.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( self::STATE_OPTION_PREFIX ) . '%'
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		$ttl = self::get_state_token_ttl();
+		$now = time();
+		foreach ( $rows as $row ) {
+			if ( ! is_numeric( $row->option_value ) || ( $now - (int) $row->option_value ) > $ttl ) {
+				delete_option( $row->option_name );
+			}
+		}
 	}
 
 	/**

--- a/tests/Unit/test-paidy-onboarding-state.php
+++ b/tests/Unit/test-paidy-onboarding-state.php
@@ -2,9 +2,10 @@
 /**
  * Tests for the Paidy onboarding state token storage.
  *
- * Covers the migration from transients (2-day TTL, evictable) to a
- * non-autoloaded option so the token survives the multi-week Paidy review
- * between wizard submission and the CSV-import key-delivery callback.
+ * Covers the migration from transients (2-day TTL, evictable) to per-token
+ * non-autoloaded options so the token survives the multi-week Paidy review
+ * between wizard submission and the CSV-import key-delivery callback, and so
+ * concurrent onboarding sessions cannot overwrite each other's tokens.
  *
  * @package Japanized_For_WooCommerce
  */
@@ -22,6 +23,20 @@ class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
 	const TOKEN = 'abcdefghijklmnopqrstuvwxyzABCDEF';
 
 	/**
+	 * A second valid token for parallel-session tests.
+	 *
+	 * @var string
+	 */
+	const OTHER_TOKEN = '0123456789abcdef0123456789abcdef';
+
+	/**
+	 * A third valid token used as an expired entry.
+	 *
+	 * @var string
+	 */
+	const EXPIRED_TOKEN = 'ZYXWVUTSRQPONMLKJIHGFEDCBA654321';
+
+	/**
 	 * Set up test environment before each test.
 	 */
 	public function setUp(): void {
@@ -36,8 +51,10 @@ class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
 	 * Tear down test environment after each test.
 	 */
 	public function tearDown(): void {
-		delete_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
-		delete_transient( 'paidy_onboarding_state_' . self::TOKEN );
+		foreach ( array( self::TOKEN, self::OTHER_TOKEN, self::EXPIRED_TOKEN ) as $token ) {
+			delete_option( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . $token );
+			delete_transient( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . $token );
+		}
 		parent::tearDown();
 	}
 
@@ -65,11 +82,26 @@ class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
 		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
 
 		// Rewind the issued timestamp to 91 days ago (TTL is 90 days).
-		$states                 = get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
-		$states[ self::TOKEN ]  = time() - ( 91 * DAY_IN_SECONDS );
-		update_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME, $states, false );
+		update_option(
+			WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::TOKEN,
+			time() - ( 91 * DAY_IN_SECONDS ),
+			false
+		);
 
 		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * A timestamp stored as a numeric string (DB round-trip) still verifies.
+	 */
+	public function test_numeric_string_timestamp_verifies() {
+		update_option(
+			WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::TOKEN,
+			(string) time(),
+			false
+		);
+
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
 	}
 
 	/**
@@ -87,65 +119,79 @@ class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A corrupted (non-array) option value does not fatal and verification fails.
+	 * A corrupted (non-numeric) option value does not fatal and verification fails.
 	 */
 	public function test_corrupted_option_does_not_fatal() {
-		update_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME, 'corrupted-string', false );
+		update_option( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::TOKEN, 'corrupted-string', false );
 
 		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
 		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN ); // Must not fatal.
 
-		// store_state_token() recovers by rebuilding the array.
+		// store_state_token() recovers by overwriting with a fresh timestamp.
 		$this->assertTrue( WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN ) );
 		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
 	}
 
 	/**
-	 * Storing a new token prunes expired entries.
+	 * Storing a new token prunes expired and corrupted entries.
 	 */
 	public function test_store_prunes_expired_entries() {
-		$expired_token = 'ZYXWVUTSRQPONMLKJIHGFEDCBA654321';
 		update_option(
-			WC_Paidy_Apply_Receiver::STATE_OPTION_NAME,
-			array( $expired_token => time() - ( 91 * DAY_IN_SECONDS ) ),
+			WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::EXPIRED_TOKEN,
+			time() - ( 91 * DAY_IN_SECONDS ),
+			false
+		);
+		update_option(
+			WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::OTHER_TOKEN,
+			'corrupted-string',
 			false
 		);
 
 		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
 
-		$states = get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
-		$this->assertArrayNotHasKey( $expired_token, $states );
-		$this->assertArrayHasKey( self::TOKEN, $states );
+		$this->assertFalse( get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::EXPIRED_TOKEN ) );
+		$this->assertFalse( get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::OTHER_TOKEN ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * Pruning does not delete legacy transient rows for other tokens.
+	 */
+	public function test_prune_leaves_legacy_transients_intact() {
+		set_transient( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::OTHER_TOKEN, 1, 2 * DAY_IN_SECONDS );
+
+		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
+
+		$this->assertNotFalse( get_transient( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::OTHER_TOKEN ) );
 	}
 
 	/**
 	 * Multiple tokens coexist (parallel onboarding sessions).
 	 */
 	public function test_parallel_tokens_coexist() {
-		$other_token = '0123456789abcdef0123456789abcdef';
 		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
-		WC_Paidy_Apply_Receiver::store_state_token( $other_token );
+		WC_Paidy_Apply_Receiver::store_state_token( self::OTHER_TOKEN );
 
 		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
-		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( $other_token ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::OTHER_TOKEN ) );
 
 		// Consuming one leaves the other intact.
 		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN );
 		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
-		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( $other_token ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::OTHER_TOKEN ) );
 	}
 
 	/**
 	 * Legacy transient-only tokens (issued by older plugin versions) still verify.
 	 */
 	public function test_legacy_transient_token_verifies_and_is_consumed() {
-		set_transient( 'paidy_onboarding_state_' . self::TOKEN, 1, 2 * DAY_IN_SECONDS );
+		set_transient( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::TOKEN, 1, 2 * DAY_IN_SECONDS );
 
 		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
 
 		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN );
 		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
-		$this->assertFalse( get_transient( 'paidy_onboarding_state_' . self::TOKEN ) );
+		$this->assertFalse( get_transient( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . self::TOKEN ) );
 	}
 
 	/**
@@ -160,6 +206,6 @@ class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
 			WC_Paidy_Apply_Receiver::consume_state_token( $bad_token ); // Must not fatal.
 		}
 
-		$this->assertFalse( get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME ) );
+		$this->assertFalse( get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX . 'short' ) );
 	}
 }

--- a/tests/Unit/test-paidy-onboarding-state.php
+++ b/tests/Unit/test-paidy-onboarding-state.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for the Paidy onboarding state token storage.
+ *
+ * Covers the migration from transients (2-day TTL, evictable) to a
+ * non-autoloaded option so the token survives the multi-week Paidy review
+ * between wizard submission and the CSV-import key-delivery callback.
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * WC_Paidy_Onboarding_State_Test
+ */
+class WC_Paidy_Onboarding_State_Test extends WP_UnitTestCase {
+
+	/**
+	 * A valid 32-char alphanumeric token used across tests.
+	 *
+	 * @var string
+	 */
+	const TOKEN = 'abcdefghijklmnopqrstuvwxyzABCDEF';
+
+	/**
+	 * Set up test environment before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( 'WC_Paidy_Apply_Receiver' ) ) {
+			require_once dirname( __DIR__, 2 ) . '/includes/gateways/paidy/class-wc-paidy-apply-receiver.php';
+		}
+	}
+
+	/**
+	 * Tear down test environment after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
+		delete_transient( 'paidy_onboarding_state_' . self::TOKEN );
+		parent::tearDown();
+	}
+
+	/**
+	 * A stored token verifies successfully.
+	 */
+	public function test_store_then_verify_returns_true() {
+		$this->assertTrue( WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * A consumed token no longer verifies (one-time use).
+	 */
+	public function test_consume_then_verify_returns_false() {
+		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
+		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN );
+		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * A token older than the TTL fails verification.
+	 */
+	public function test_expired_token_fails_verification() {
+		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
+
+		// Rewind the issued timestamp to 91 days ago (TTL is 90 days).
+		$states                 = get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
+		$states[ self::TOKEN ]  = time() - ( 91 * DAY_IN_SECONDS );
+		update_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME, $states, false );
+
+		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * The TTL is filterable via wc4jp_paidy_onboarding_state_ttl.
+	 */
+	public function test_ttl_is_filterable() {
+		$this->assertSame( 90 * DAY_IN_SECONDS, WC_Paidy_Apply_Receiver::get_state_token_ttl() );
+
+		$shorten = function () {
+			return DAY_IN_SECONDS;
+		};
+		add_filter( 'wc4jp_paidy_onboarding_state_ttl', $shorten );
+		$this->assertSame( DAY_IN_SECONDS, WC_Paidy_Apply_Receiver::get_state_token_ttl() );
+		remove_filter( 'wc4jp_paidy_onboarding_state_ttl', $shorten );
+	}
+
+	/**
+	 * A corrupted (non-array) option value does not fatal and verification fails.
+	 */
+	public function test_corrupted_option_does_not_fatal() {
+		update_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME, 'corrupted-string', false );
+
+		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN ); // Must not fatal.
+
+		// store_state_token() recovers by rebuilding the array.
+		$this->assertTrue( WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+	}
+
+	/**
+	 * Storing a new token prunes expired entries.
+	 */
+	public function test_store_prunes_expired_entries() {
+		$expired_token = 'ZYXWVUTSRQPONMLKJIHGFEDCBA654321';
+		update_option(
+			WC_Paidy_Apply_Receiver::STATE_OPTION_NAME,
+			array( $expired_token => time() - ( 91 * DAY_IN_SECONDS ) ),
+			false
+		);
+
+		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
+
+		$states = get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME );
+		$this->assertArrayNotHasKey( $expired_token, $states );
+		$this->assertArrayHasKey( self::TOKEN, $states );
+	}
+
+	/**
+	 * Multiple tokens coexist (parallel onboarding sessions).
+	 */
+	public function test_parallel_tokens_coexist() {
+		$other_token = '0123456789abcdef0123456789abcdef';
+		WC_Paidy_Apply_Receiver::store_state_token( self::TOKEN );
+		WC_Paidy_Apply_Receiver::store_state_token( $other_token );
+
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( $other_token ) );
+
+		// Consuming one leaves the other intact.
+		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN );
+		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( $other_token ) );
+	}
+
+	/**
+	 * Legacy transient-only tokens (issued by older plugin versions) still verify.
+	 */
+	public function test_legacy_transient_token_verifies_and_is_consumed() {
+		set_transient( 'paidy_onboarding_state_' . self::TOKEN, 1, 2 * DAY_IN_SECONDS );
+
+		$this->assertTrue( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+
+		WC_Paidy_Apply_Receiver::consume_state_token( self::TOKEN );
+		$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( self::TOKEN ) );
+		$this->assertFalse( get_transient( 'paidy_onboarding_state_' . self::TOKEN ) );
+	}
+
+	/**
+	 * Malformed tokens are rejected by every helper without touching storage.
+	 */
+	public function test_malformed_tokens_rejected() {
+		$malformed = array( '', 'short', str_repeat( 'a', 33 ), 'has-hyphens-not-allowed-in-token', array( 'x' ), null, 123 );
+
+		foreach ( $malformed as $bad_token ) {
+			$this->assertFalse( WC_Paidy_Apply_Receiver::store_state_token( $bad_token ) );
+			$this->assertFalse( WC_Paidy_Apply_Receiver::verify_state_token( $bad_token ) );
+			WC_Paidy_Apply_Receiver::consume_state_token( $bad_token ); // Must not fatal.
+		}
+
+		$this->assertFalse( get_option( WC_Paidy_Apply_Receiver::STATE_OPTION_NAME ) );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -51,11 +51,14 @@ function wc_paidy_delete_plugin() {
 	// Delete onboarding state token options (one non-autoloaded row per token,
 	// named paidy_onboarding_state_<token>) — the random suffixes cannot be
 	// enumerated via a core API, so a direct LIKE query is required.
+	// Must match WC_Paidy_Apply_Receiver::STATE_OPTION_PREFIX (the class is not
+	// loaded during uninstall, so the constant cannot be referenced directly).
+	$state_option_prefix = 'paidy_onboarding_state_';
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$wpdb->query(
 		$wpdb->prepare(
 			"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-			$wpdb->esc_like( 'paidy_onboarding_state_' ) . '%'
+			$wpdb->esc_like( $state_option_prefix ) . '%'
 		)
 	);
 	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/uninstall.php
+++ b/uninstall.php
@@ -47,6 +47,7 @@ function wc_paidy_delete_plugin() {
 		}
 	}
 	delete_option( 'wc_paidy_show_pr_notice' );
+	delete_option( 'paidy_onboarding_states' );
 }
 
 wc_paidy_delete_plugin();

--- a/uninstall.php
+++ b/uninstall.php
@@ -47,7 +47,18 @@ function wc_paidy_delete_plugin() {
 		}
 	}
 	delete_option( 'wc_paidy_show_pr_notice' );
-	delete_option( 'paidy_onboarding_states' );
+
+	// Delete onboarding state token options (one non-autoloaded row per token,
+	// named paidy_onboarding_state_<token>) — the random suffixes cannot be
+	// enumerated via a core API, so a direct LIKE query is required.
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+			$wpdb->esc_like( 'paidy_onboarding_state_' ) . '%'
+		)
+	);
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
 wc_paidy_delete_plugin();


### PR DESCRIPTION
## Summary

Fixes the `403 paidy_invalid_state` error on Instant Onboarding CSV import (reported for application WC000000561).

The one-time state token verified by the `paidy-receiver/v1/receive` REST endpoint was stored as a **transient with a 2-day TTL**, but the Paidy merchant review between the wizard application and the key-delivery callback takes days to weeks. By the time the intermediary posted the API keys back, the transient had expired and every callback failed with `403 paidy_invalid_state`.

## Changes

- **`class-wc-paidy-apply-receiver.php`** — store each token as its own **non-autoloaded option** (`paidy_onboarding_state_<token>` = issued UNIX time) with a filterable 90-day TTL (`wc4jp_paidy_onboarding_state_ttl`). One row per token means concurrent onboarding sessions insert separate rows and cannot overwrite each other, matching the isolation of the previous transient-based storage:
  - `store_state_token()` prunes expired/corrupted rows on every store (no cron needed) and verifies persistence by re-reading the option
  - `verify_state_token()` falls back to the legacy transient so tokens issued by older plugin versions keep working during the transition (to be removed after 2–3 releases)
  - `consume_state_token()` deletes the option row and the legacy transient
  - One-time consumption on success and the API contract (`state` param, `paidy_invalid_state` / 403) are unchanged
- **`class-wc-paidy-admin-wizard.php`** — replace `set_transient` (2-day TTL) with `store_state_token()`, and the two failure-cleanup `delete_transient` calls with `consume_state_token()`
- **`uninstall.php`** — delete the `paidy_onboarding_state_*` option rows on uninstall
- **`tests/Unit/test-paidy-onboarding-state.php`** — 11 new unit tests

## Testing

- PHPUnit: 95 tests / 180 assertions pass, including 11 new tests covering store/verify/consume, TTL expiry, pruning (including that legacy transients are left intact), corrupted option values, numeric-string timestamps after DB round-trips, parallel tokens, the legacy transient fallback, and malformed-token rejection
- PHPCS: no new violations in changed files
- E2E on wp-env: simulated the wizard application with the outbound POST to the intermediary mocked via `pre_http_request` (real token generation/storage code path) → token stored as its own non-autoloaded option → curl POST of AES-encrypted keys + state to the receive endpoint → **200**, keys decrypted and saved to `woocommerce_paidy_settings`, token consumed → re-POST of the same state → **403** (one-time use confirmed)

## Backward compatibility

The API contract is unchanged, so plugin and intermediary can be deployed in either order. Tokens issued by older plugin versions (transient-based) are still accepted while their transient is alive via the legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)