### PR TITLE
docs: apply remaining Copilot review fixes from PR #198

### DIFF
--- a/.claude/skills/woo-marketplace-qit/SKILL.md
+++ b/.claude/skills/woo-marketplace-qit/SKILL.md
@@ -298,7 +298,7 @@ test.describe( 'Checkout Integration', () => {
   </rule>
 
   <!-- PHP Compatibility -->
-  <config name="testVersion" value="8.3-"/>
+  <config name="testVersion" value="8.3-8.5"/>
   <rule ref="PHPCompatibilityWP"/>
 
   <!-- Minimum WP version -->

--- a/.claude/skills/woo-marketplace-submission/SKILL.md
+++ b/.claude/skills/woo-marketplace-submission/SKILL.md
@@ -335,7 +335,7 @@ The review team will actually interact with the product to verify UX, so prepare
 Products listed on the marketplace require ongoing maintenance:
 
 - **Minimum update every 6 months**: Products without updates for 6+ months are subject to delisting
-- **Quarterly major releases recommended**: WooCommerce Core ships major versions roughly monthly, so verify compatibility with each Core release and fold the results into at least quarterly releases of your extension
+- **Quarterly major releases recommended**: WooCommerce Core ships major versions roughly monthly. Verify compatibility with each new Core release, then publish an extension release at least quarterly (or sooner if compatibility issues are found).
 - **Security fixes**: Emergency releases as needed
 - **Minor improvements**: Monthly or as features/fixes are ready
 


### PR DESCRIPTION
Applies the two remaining valid fixes flagged by Copilot code review on PR #198, superseding PR #199 (created by the Copilot coding agent from a stale snapshot of the #198 branch).

## Changes

- **`woo-marketplace-qit/SKILL.md`** — bound the `PHPCompatibilityWP` `testVersion` example to `8.3-8.5`. The surrounding docs and the CI matrix already state PHP 8.3–8.5, so the open-ended `8.3-` was internally inconsistent and would lint against unreleased PHP versions.
- **`woo-marketplace-submission/SKILL.md`** — clarified the release cadence guidance: verify compatibility with each monthly WC Core release, then publish at least quarterly (or sooner when compatibility issues are found).

## Not applied from PR #199

The "iframed editor" → "iframe editor" rename is intentionally excluded: current main already uses "iframed editor" consistently (no mixed terminology remains), and it matches upstream Gutenberg dev-note terminology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)