### PR TITLE
fix: dedupe yomigana on admin order edit screen for block checkout orders

### DIFF
--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -724,7 +724,7 @@ class JP4WC_Address_Fields {
 	/**
 	 * Deduplicate yomigana billing fields on the admin order edit screen.
 	 *
-	 * @since 2.9.9
+	 * @since 2.9.15
 	 * @param array               $fields The admin billing fields.
 	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
 	 * @return array
@@ -736,7 +736,7 @@ class JP4WC_Address_Fields {
 	/**
 	 * Deduplicate yomigana shipping fields on the admin order edit screen.
 	 *
-	 * @since 2.9.9
+	 * @since 2.9.15
 	 * @param array               $fields The admin shipping fields.
 	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
 	 * @return array
@@ -762,7 +762,7 @@ class JP4WC_Address_Fields {
 	 * keep only the pair matching the meta the order actually stores. Orders without
 	 * any yomigana meta keep the pair matching the current checkout page type.
 	 *
-	 * @since 2.9.9
+	 * @since 2.9.15
 	 * @param array               $fields The admin address fields.
 	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
 	 * @param string              $group  Address group: 'billing' or 'shipping'.

--- a/includes/class-jp4wc-address-fields.php
+++ b/includes/class-jp4wc-address-fields.php
@@ -56,6 +56,11 @@ class JP4WC_Address_Fields {
 		// Admin Edit Address.
 		add_filter( 'woocommerce_admin_billing_fields', array( $this, 'admin_billing_address_fields' ) );
 		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_shipping_address_fields' ) );
+		// Deduplicate yomigana fields injected by the WC Additional Checkout Fields API
+		// (CheckoutFieldsAdmin, priority 10) on the admin order edit screen. Must run
+		// after both that injection and admin_billing/shipping_address_fields() above.
+		add_filter( 'woocommerce_admin_billing_fields', array( $this, 'admin_billing_dedupe_yomigana_fields' ), 20, 2 );
+		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_shipping_dedupe_yomigana_fields' ), 20, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_order_enqueue_style' ), 20 );
 		add_filter( 'woocommerce_customer_meta_fields', array( $this, 'admin_customer_meta_fields' ) );
 
@@ -714,6 +719,106 @@ class JP4WC_Address_Fields {
 		}
 
 		return $ordered;
+	}
+
+	/**
+	 * Deduplicate yomigana billing fields on the admin order edit screen.
+	 *
+	 * @since 2.9.9
+	 * @param array               $fields The admin billing fields.
+	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
+	 * @return array
+	 */
+	public function admin_billing_dedupe_yomigana_fields( $fields, $order = null ) {
+		return $this->dedupe_admin_yomigana_fields( $fields, $order, 'billing' );
+	}
+
+	/**
+	 * Deduplicate yomigana shipping fields on the admin order edit screen.
+	 *
+	 * @since 2.9.9
+	 * @param array               $fields The admin shipping fields.
+	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
+	 * @return array
+	 */
+	public function admin_shipping_dedupe_yomigana_fields( $fields, $order = null ) {
+		return $this->dedupe_admin_yomigana_fields( $fields, $order, 'shipping' );
+	}
+
+	/**
+	 * Deduplicate yomigana fields on the admin order edit screen.
+	 *
+	 * For block checkout orders, WooCommerce core (CheckoutFieldsAdmin) injects the
+	 * Additional Checkout Fields API yomigana fields (id `_wc_billing/jp4wc/yomigana_*` /
+	 * `_wc_shipping/jp4wc/yomigana_*`) with `show => true`, which the order data meta box
+	 * echoes below the formatted address.
+	 * The formatted address already contains yomigana (see jp4wc_billing_address() /
+	 * address_formats()), so that echo duplicates it — suppress it with `show => false`.
+	 * The edit form ignores `show`, so the fields remain editable and keep persisting
+	 * to `_wc_billing/jp4wc/*` / `_wc_shipping/jp4wc/*` via WC core's update callback.
+	 *
+	 * The edit form would also render two pairs of yomigana inputs (the classic pair
+	 * bound to `_billing_yomigana_*` / `_shipping_yomigana_*` plus the block pair), so
+	 * keep only the pair matching the meta the order actually stores. Orders without
+	 * any yomigana meta keep the pair matching the current checkout page type.
+	 *
+	 * @since 2.9.9
+	 * @param array               $fields The admin address fields.
+	 * @param \WC_Order|bool|null $order  The order being displayed, or false/null outside an order context.
+	 * @param string              $group  Address group: 'billing' or 'shipping'.
+	 * @return array
+	 */
+	private function dedupe_admin_yomigana_fields( $fields, $order, $group ) {
+		if ( ! $order instanceof WC_Order ) {
+			return $fields;
+		}
+
+		$classic_keys = array( 'yomigana_last_name', 'yomigana_first_name' );
+
+		// CheckoutFieldsAdmin inserts its fields with array_splice(), which does not
+		// preserve their string keys (they become numeric), so detect the injected
+		// fields by their 'id' (always set to the prefixed meta key) instead.
+		$block_ids  = array(
+			'_wc_' . $group . '/jp4wc/yomigana_last_name',
+			'_wc_' . $group . '/jp4wc/yomigana_first_name',
+		);
+		$block_keys = array();
+		foreach ( $fields as $key => $field ) {
+			if ( isset( $field['id'] ) && in_array( $field['id'], $block_ids, true ) ) {
+				$block_keys[] = $key;
+			}
+		}
+
+		if ( empty( $block_keys ) ) {
+			return $fields;
+		}
+
+		// Suppress the duplicate view-mode rows (yomigana is already in the formatted address).
+		foreach ( $block_keys as $key ) {
+			$fields[ $key ]['show'] = false;
+		}
+
+		$classic_prefix   = '_' . $group . '_yomigana_';
+		$block_prefix     = '_wc_' . $group . '/jp4wc/yomigana_';
+		$has_classic_meta = '' !== $order->get_meta( $classic_prefix . 'last_name' ) || '' !== $order->get_meta( $classic_prefix . 'first_name' );
+		$has_block_meta   = '' !== $order->get_meta( $block_prefix . 'last_name' ) || '' !== $order->get_meta( $block_prefix . 'first_name' );
+
+		if ( $has_classic_meta ) {
+			// Classic meta wins when both exist, matching jp4wc_billing_address().
+			$keep_block = false;
+		} elseif ( $has_block_meta ) {
+			$keep_block = true;
+		} else {
+			$checkout_page_id = wc_get_page_id( 'checkout' );
+			$keep_block       = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
+		}
+
+		$remove_keys = $keep_block ? $classic_keys : $block_keys;
+		foreach ( $remove_keys as $key ) {
+			unset( $fields[ $key ] );
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/tests/Unit/test-jp4wc-admin-order-yomigana.php
+++ b/tests/Unit/test-jp4wc-admin-order-yomigana.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Class JP4WC_Admin_Order_Yomigana_Test
+ *
+ * Tests deduplication of yomigana fields on the admin order edit screen.
+ * WooCommerce core (CheckoutFieldsAdmin) injects Additional Checkout Fields API
+ * yomigana fields with `show => true`, duplicating the yomigana already embedded
+ * in the formatted address, and doubling the edit-form inputs.
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * JP4WC_Admin_Order_Yomigana_Test test case.
+ */
+class JP4WC_Admin_Order_Yomigana_Test extends WP_UnitTestCase {
+
+	/**
+	 * Address fields instance under test.
+	 *
+	 * @var JP4WC_Address_Fields
+	 */
+	private $address_fields;
+
+	/**
+	 * A preparation method that is always called before each test is run.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->address_fields = new JP4WC_Address_Fields();
+	}
+
+	/**
+	 * Build the admin fields array as it looks after WC core injected the
+	 * Additional Checkout Fields API yomigana fields and the plugin added its
+	 * classic pair with `show => false`. CheckoutFieldsAdmin inserts its fields
+	 * via array_splice(), which does not preserve string keys, so the injected
+	 * fields carry numeric keys and are identified by their 'id'.
+	 *
+	 * @param string $group      Address group: 'billing' or 'shipping'.
+	 * @param string $last_name  Value for the block last name field.
+	 * @param string $first_name Value for the block first name field.
+	 * @return array
+	 */
+	private function get_admin_fields_with_block_yomigana( $group = 'billing', $last_name = 'やまだ', $first_name = 'たろう' ) {
+		return array(
+			'last_name'           => array( 'label' => 'Last name' ),
+			'first_name'          => array( 'label' => 'First name' ),
+			'yomigana_last_name'  => array(
+				'label' => 'Last Name Yomigana',
+				'show'  => false,
+			),
+			'yomigana_first_name' => array(
+				'label' => 'First Name Yomigana',
+				'show'  => false,
+			),
+			'state'               => array( 'label' => 'State' ),
+			0                     => array(
+				'id'    => '_wc_' . $group . '/jp4wc/yomigana_last_name',
+				'label' => 'Last Name ( Yomigana )',
+				'value' => $last_name,
+				'show'  => true,
+			),
+			1                     => array(
+				'id'    => '_wc_' . $group . '/jp4wc/yomigana_first_name',
+				'label' => 'First Name ( Yomigana )',
+				'value' => $first_name,
+				'show'  => true,
+			),
+			'city'                => array( 'label' => 'City' ),
+		);
+	}
+
+	/**
+	 * Find a field by its 'id' in the admin fields array.
+	 *
+	 * @param array  $fields The admin fields array.
+	 * @param string $id     The field id to look for.
+	 * @return array|null The field, or null when absent.
+	 */
+	private function find_field_by_id( $fields, $id ) {
+		foreach ( $fields as $field ) {
+			if ( isset( $field['id'] ) && $id === $field['id'] ) {
+				return $field;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Create an order with block-format (Additional Checkout Fields API) yomigana meta.
+	 *
+	 * @param string $group Address group: 'billing' or 'shipping'.
+	 * @return WC_Order
+	 */
+	private function create_block_order( $group = 'billing' ) {
+		$order = new WC_Order();
+		$order->update_meta_data( '_wc_' . $group . '/jp4wc/yomigana_last_name', 'やまだ' );
+		$order->update_meta_data( '_wc_' . $group . '/jp4wc/yomigana_first_name', 'たろう' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Create an order with classic-format yomigana meta.
+	 *
+	 * @param string $group Address group: 'billing' or 'shipping'.
+	 * @return WC_Order
+	 */
+	private function create_classic_order( $group = 'billing' ) {
+		$order = new WC_Order();
+		$order->update_meta_data( '_' . $group . '_yomigana_last_name', 'やまだ' );
+		$order->update_meta_data( '_' . $group . '_yomigana_first_name', 'たろう' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Block order: WC-injected fields must be hidden from view mode (show => false)
+	 * and the classic pair removed from the edit form.
+	 */
+	public function test_block_order_hides_view_rows_and_removes_classic_pair() {
+		$order  = $this->create_block_order( 'billing' );
+		$fields = $this->address_fields->admin_billing_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'billing' ),
+			$order
+		);
+
+		$block_last  = $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_last_name' );
+		$block_first = $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_first_name' );
+
+		$this->assertNotNull( $block_last, 'Block yomigana last name should be kept' );
+		$this->assertNotNull( $block_first, 'Block yomigana first name should be kept' );
+		$this->assertFalse( $block_last['show'], 'Block yomigana last name should be hidden in view mode' );
+		$this->assertFalse( $block_first['show'], 'Block yomigana first name should be hidden in view mode' );
+		$this->assertSame( 'やまだ', $block_last['value'], 'Block field value should be preserved' );
+		$this->assertArrayNotHasKey( 'yomigana_last_name', $fields, 'Classic yomigana last name should be removed from the edit form' );
+		$this->assertArrayNotHasKey( 'yomigana_first_name', $fields, 'Classic yomigana first name should be removed from the edit form' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Classic order: the WC-injected block pair must be removed entirely and the
+	 * classic pair kept for the edit form.
+	 */
+	public function test_classic_order_removes_block_pair_and_keeps_classic_pair() {
+		$order  = $this->create_classic_order( 'billing' );
+		$fields = $this->address_fields->admin_billing_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'billing', '', '' ),
+			$order
+		);
+
+		$this->assertNull( $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_last_name' ), 'Block yomigana last name should be removed for classic orders' );
+		$this->assertNull( $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_first_name' ), 'Block yomigana first name should be removed for classic orders' );
+		$this->assertArrayHasKey( 'yomigana_last_name', $fields, 'Classic yomigana last name should be kept for classic orders' );
+		$this->assertArrayHasKey( 'yomigana_first_name', $fields, 'Classic yomigana first name should be kept for classic orders' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * When both meta formats exist, classic wins, matching jp4wc_billing_address().
+	 */
+	public function test_order_with_both_meta_prefers_classic_pair() {
+		$order = new WC_Order();
+		$order->update_meta_data( '_billing_yomigana_last_name', 'すずき' );
+		$order->update_meta_data( '_wc_billing/jp4wc/yomigana_last_name', 'やまだ' );
+		$order->save();
+
+		$fields = $this->address_fields->admin_billing_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'billing' ),
+			$order
+		);
+
+		$this->assertNull( $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_last_name' ), 'Block pair should be removed when classic meta exists' );
+		$this->assertArrayHasKey( 'yomigana_last_name', $fields, 'Classic pair should be kept when classic meta exists' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Shipping group uses `_wc_shipping/jp4wc/*` meta and the shipping wrapper.
+	 */
+	public function test_shipping_block_order_hides_view_rows_and_removes_classic_pair() {
+		$order  = $this->create_block_order( 'shipping' );
+		$fields = $this->address_fields->admin_shipping_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'shipping' ),
+			$order
+		);
+
+		$block_last = $this->find_field_by_id( $fields, '_wc_shipping/jp4wc/yomigana_last_name' );
+
+		$this->assertNotNull( $block_last, 'Block yomigana should be kept in the shipping fields' );
+		$this->assertFalse( $block_last['show'], 'Block yomigana should be hidden in shipping view mode' );
+		$this->assertArrayNotHasKey( 'yomigana_last_name', $fields, 'Classic yomigana should be removed from the shipping edit form' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Without an order (e.g. the initial get_billing_fields() call in the meta box),
+	 * the fields must pass through unchanged.
+	 */
+	public function test_no_order_returns_fields_unchanged() {
+		$fields = $this->get_admin_fields_with_block_yomigana( 'billing' );
+
+		$this->assertSame( $fields, $this->address_fields->admin_billing_dedupe_yomigana_fields( $fields, null ) );
+		$this->assertSame( $fields, $this->address_fields->admin_billing_dedupe_yomigana_fields( $fields, false ) );
+	}
+
+	/**
+	 * Without WC-injected block fields (classic-only environment), the fields must
+	 * pass through unchanged.
+	 */
+	public function test_fields_without_block_fields_are_unchanged() {
+		$order  = $this->create_classic_order( 'billing' );
+		$fields = array(
+			'last_name'           => array( 'label' => 'Last name' ),
+			'yomigana_last_name'  => array(
+				'label' => 'Last Name Yomigana',
+				'show'  => false,
+			),
+			'yomigana_first_name' => array(
+				'label' => 'First Name Yomigana',
+				'show'  => false,
+			),
+		);
+
+		$this->assertSame( $fields, $this->address_fields->admin_billing_dedupe_yomigana_fields( $fields, $order ) );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Order without any yomigana meta on a classic checkout page keeps the classic
+	 * pair and removes the block pair.
+	 */
+	public function test_empty_order_on_classic_checkout_keeps_classic_pair() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'   => 'Checkout',
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '[woocommerce_checkout]',
+			)
+		);
+		update_option( 'woocommerce_checkout_page_id', $page_id );
+
+		$order = new WC_Order();
+		$order->save();
+
+		$fields = $this->address_fields->admin_billing_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'billing', '', '' ),
+			$order
+		);
+
+		$this->assertNull( $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_last_name' ), 'Block pair should be removed on classic checkout setups' );
+		$this->assertArrayHasKey( 'yomigana_last_name', $fields, 'Classic pair should be kept on classic checkout setups' );
+
+		$order->delete( true );
+		wp_delete_post( $page_id, true );
+		delete_option( 'woocommerce_checkout_page_id' );
+	}
+
+	/**
+	 * Order without any yomigana meta on a block checkout page keeps the block pair
+	 * (hidden in view mode) and removes the classic pair.
+	 */
+	public function test_empty_order_on_block_checkout_keeps_block_pair() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'   => 'Checkout',
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout"></div><!-- /wp:woocommerce/checkout -->',
+			)
+		);
+		update_option( 'woocommerce_checkout_page_id', $page_id );
+
+		$order = new WC_Order();
+		$order->save();
+
+		$fields = $this->address_fields->admin_billing_dedupe_yomigana_fields(
+			$this->get_admin_fields_with_block_yomigana( 'billing', '', '' ),
+			$order
+		);
+
+		$block_last = $this->find_field_by_id( $fields, '_wc_billing/jp4wc/yomigana_last_name' );
+
+		$this->assertNotNull( $block_last, 'Block pair should be kept on block checkout setups' );
+		$this->assertFalse( $block_last['show'], 'Block pair should stay hidden in view mode' );
+		$this->assertArrayNotHasKey( 'yomigana_last_name', $fields, 'Classic pair should be removed on block checkout setups' );
+
+		$order->delete( true );
+		wp_delete_post( $page_id, true );
+		delete_option( 'woocommerce_checkout_page_id' );
+	}
+
+	/**
+	 * The dedupe filters must be registered at priority 20, after WC core's
+	 * CheckoutFieldsAdmin injection at priority 10.
+	 */
+	public function test_filters_registered_at_priority_20() {
+		$this->assertSame(
+			20,
+			has_filter( 'woocommerce_admin_billing_fields', array( $this->address_fields, 'admin_billing_dedupe_yomigana_fields' ) ),
+			'Billing dedupe filter should be registered at priority 20'
+		);
+		$this->assertSame(
+			20,
+			has_filter( 'woocommerce_admin_shipping_fields', array( $this->address_fields, 'admin_shipping_dedupe_yomigana_fields' ) ),
+			'Shipping dedupe filter should be registered at priority 20'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

For orders placed via the block checkout (Store API), the admin order edit screen displayed yomigana twice in the billing/shipping address boxes:

- **Top**: inside the formatted address, where JP4WC embeds it via `jp4wc_billing_address()` / `address_formats()`
- **Bottom**: as separate `<p><strong>label:</strong> value</p>` rows echoed by the order data meta box, because WooCommerce core's `CheckoutFieldsAdmin` injects the Additional Checkout Fields API yomigana fields into `woocommerce_admin_billing/shipping_fields` with `show => true`

The pencil-icon edit form also rendered **two pairs** of yomigana inputs: the classic pair bound to `_billing/_shipping_yomigana_*` meta (empty for block orders) plus the WC-injected block pair.

## Fix

Added dedupe filters at priority 20 (after WC core's injection at priority 10) in `JP4WC_Address_Fields`:

- Set `show => false` on the WC-injected yomigana fields so the duplicate view-mode rows disappear. The edit form ignores `show`, so the fields remain editable and keep persisting to `_wc_billing/jp4wc/*` / `_wc_shipping/jp4wc/*` via WC core's update callback.
- Keep only the edit-form input pair matching the meta the order actually stores: classic wins when both exist (matching `jp4wc_billing_address()`); orders without any yomigana meta fall back to the current checkout page type.

Note: the injected fields are detected by their `id` (`_wc_billing/jp4wc/yomigana_*`) rather than array key, because `CheckoutFieldsAdmin` inserts them with `array_splice()`, which replaces their string keys with numeric ones.

This mirrors the approach of #197 (frontend order display dedupe): the formatted-address embedding is the canonical display, and the Additional Checkout Fields API duplicate output is suppressed.

## Testing

- Added `tests/Unit/test-jp4wc-admin-order-yomigana.php` (9 tests) covering block orders, classic orders, both-meta orders, shipping group, no-order pass-through, and the empty-meta fallback by checkout page type
- Full PHPUnit suite passes: 104 tests, 206 assertions
- PHPCS clean on changed files
- Verified end-to-end in wp-env against a real block-checkout order (billing/shipping × view/edit): injected fields get `show=false` with values preserved, the classic input pair is removed, and the formatted address still contains yomigana

🤖 Generated with [Claude Code](https://claude.com/claude-code)