### PR TITLE
fix: balance Paidy description HTML to stop duplicated order buttons

### DIFF
--- a/includes/gateways/paidy/class-wc-gateway-paidy.php
+++ b/includes/gateways/paidy/class-wc-gateway-paidy.php
@@ -375,7 +375,7 @@ class WC_Gateway_Paidy extends WC_Payment_Gateway {
 	 * @return string Sanitized value with balanced tags.
 	 */
 	public function validate_paidy_description_field( $key, $value ) {
-		$value = is_null( $value ) ? '' : trim( stripslashes( $value ) );
+		$value = is_null( $value ) ? '' : trim( wp_unslash( $value ) );
 		return wp_kses( force_balance_tags( $value ), $this->paidy_description_allowed_html() );
 	}
 

--- a/includes/gateways/paidy/class-wc-gateway-paidy.php
+++ b/includes/gateways/paidy/class-wc-gateway-paidy.php
@@ -334,7 +334,18 @@ class WC_Gateway_Paidy extends WC_Payment_Gateway {
 		} else {
 			$paidy_explanation = $this->paidy_description;
 		}
-		$allowed_html = array(
+		echo wp_kses( force_balance_tags( $paidy_explanation ), $this->paidy_description_allowed_html() );
+	}
+
+	/**
+	 * Allowed HTML tags for the Paidy description output.
+	 *
+	 * @since 2.9.15
+	 *
+	 * @return array Allowed HTML for wp_kses().
+	 */
+	private function paidy_description_allowed_html() {
+		return array(
 			'a'      => array(
 				'href'   => array(),
 				'target' => array(),
@@ -346,7 +357,26 @@ class WC_Gateway_Paidy extends WC_Payment_Gateway {
 			'ul'     => array(),
 			'li'     => array(),
 		);
-		echo wp_kses( $paidy_explanation, $allowed_html );
+	}
+
+	/**
+	 * Validate the Paidy description field on save.
+	 *
+	 * The wp_kses() function does not fix unbalanced tags, and a stray closing tag saved in
+	 * this field escapes the payment box when the classic checkout payment
+	 * fragment is re-rendered, leaving an orphaned place-order row behind on
+	 * every update_order_review call (duplicated order buttons). Balance the
+	 * tags before saving so broken markup never reaches the checkout.
+	 *
+	 * @since 2.9.15
+	 *
+	 * @param string      $key   Field key.
+	 * @param string|null $value Posted value.
+	 * @return string Sanitized value with balanced tags.
+	 */
+	public function validate_paidy_description_field( $key, $value ) {
+		$value = is_null( $value ) ? '' : trim( stripslashes( $value ) );
+		return wp_kses( force_balance_tags( $value ), $this->paidy_description_allowed_html() );
 	}
 
 	/**

--- a/tests/Unit/test-paidy-description-balance.php
+++ b/tests/Unit/test-paidy-description-balance.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for balancing the Paidy description HTML.
+ *
+ * The paidy_description setting is admin-editable HTML pre-filled with a
+ * multi-line explanation (div + ul + li). wp_kses() does not fix unbalanced
+ * tags, so a stray closing tag saved in this field escaped the payment box
+ * when the classic checkout payment fragment was re-rendered via
+ * update_order_review, leaving an orphaned place-order row behind on every
+ * checkout update (duplicated order buttons). Covers the force_balance_tags()
+ * fix on both the save path and the output path.
+ *
+ * @package Japanized_For_WooCommerce
+ */
+
+/**
+ * WC_Paidy_Description_Balance_Test
+ */
+class WC_Paidy_Description_Balance_Test extends WP_UnitTestCase {
+
+	/**
+	 * Gateway instance under test.
+	 *
+	 * @var WC_Gateway_Paidy
+	 */
+	private $gateway;
+
+	/**
+	 * Set up test environment before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( 'WC_Gateway_Paidy' ) ) {
+			$this->markTestSkipped( 'WC_Gateway_Paidy is not loaded.' );
+		}
+		$this->gateway = new WC_Gateway_Paidy();
+	}
+
+	/**
+	 * A stray closing tag must be removed on save.
+	 */
+	public function test_validate_removes_stray_closing_tag() {
+		$result = $this->gateway->validate_paidy_description_field(
+			'paidy_description',
+			'<div>Paidyで翌月払い</div></div>'
+		);
+
+		$this->assertSame( '<div>Paidyで翌月払い</div>', $result );
+	}
+
+	/**
+	 * An unclosed tag must be closed on save.
+	 */
+	public function test_validate_closes_unclosed_tag() {
+		$result = $this->gateway->validate_paidy_description_field(
+			'paidy_description',
+			'<div><ul><li>登録不要'
+		);
+
+		$this->assertSame( '<div><ul><li>登録不要</li></ul></div>', $result );
+	}
+
+	/**
+	 * Disallowed tags must be stripped while allowed markup is kept.
+	 */
+	public function test_validate_strips_disallowed_tags() {
+		$result = $this->gateway->validate_paidy_description_field(
+			'paidy_description',
+			'<div><script>alert(1)</script><strong>OK</strong></div>'
+		);
+
+		$this->assertStringNotContainsString( '<script', $result );
+		$this->assertStringContainsString( '<strong>OK</strong>', $result );
+	}
+
+	/**
+	 * The default explanation must survive validation unchanged in structure.
+	 */
+	public function test_validate_keeps_default_explanation_balanced() {
+		$default = $this->gateway->get_form_fields()['paidy_description']['default'];
+
+		$result = $this->gateway->validate_paidy_description_field( 'paidy_description', $default );
+
+		$this->assertSame(
+			substr_count( $result, '<div' ),
+			substr_count( $result, '</div' ),
+			'div tags should stay balanced'
+		);
+		$this->assertStringContainsString( '<ul>', $result );
+		$this->assertSame(
+			substr_count( $result, '<li' ),
+			substr_count( $result, '</li' ),
+			'li tags should stay balanced'
+		);
+	}
+
+	/**
+	 * payment_fields() must emit balanced HTML even when the saved setting
+	 * already contains a stray closing tag (pre-fix data).
+	 */
+	public function test_payment_fields_output_is_balanced_with_broken_setting() {
+		$this->gateway->paidy_description = '<div>Paidyで翌月払い</div></div>';
+
+		ob_start();
+		$this->gateway->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<div>Paidyで翌月払い</div>', $output );
+		$this->assertSame(
+			substr_count( $output, '<div' ),
+			substr_count( $output, '</div' ),
+			'payment_fields output must not leak unbalanced closing tags into the checkout fragment'
+		);
+	}
+
+	/**
+	 * payment_fields() must fall back to the built-in explanation when the
+	 * setting is empty, and that output must be balanced too.
+	 */
+	public function test_payment_fields_default_output_is_balanced() {
+		$this->gateway->paidy_description = '';
+
+		ob_start();
+		$this->gateway->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<ul>', $output );
+		$this->assertSame(
+			substr_count( $output, '<div' ),
+			substr_count( $output, '</div' )
+		);
+	}
+}

--- a/tests/Unit/test-paidy-description-balance.php
+++ b/tests/Unit/test-paidy-description-balance.php
@@ -32,8 +32,9 @@ class WC_Paidy_Description_Balance_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		if ( ! class_exists( 'WC_Gateway_Paidy' ) ) {
-			$this->markTestSkipped( 'WC_Gateway_Paidy is not loaded.' );
+			require_once dirname( __DIR__, 2 ) . '/includes/gateways/paidy/class-wc-gateway-paidy.php';
 		}
+		$this->assertTrue( class_exists( 'WC_Gateway_Paidy' ), 'WC_Gateway_Paidy should be loadable.' );
 		$this->gateway = new WC_Gateway_Paidy();
 	}
 


### PR DESCRIPTION
## Summary

Fixes the bug reported on the WordPress.org support forum: [Paidy導入後注文ボタンが複数表示される](https://wordpress.org/support/topic/paidy%e5%b0%8e%e5%85%a5%e5%be%8c%e6%b3%a8%e6%96%87%e3%83%9c%e3%82%bf%e3%83%b3%e3%81%8c%e8%a4%87%e6%95%b0%e8%a1%a8%e7%a4%ba%e3%81%95%e3%82%8c%e3%82%8b/) — on the classic checkout, the place-order row (privacy text + terms checkbox + order button) accumulates one extra copy on every checkout update, with stale copies keeping the old button label.

## Root cause

`payment_fields()` echoes the admin-editable `paidy_description` setting through `wp_kses()`, which does **not** fix unbalanced tags. The settings textarea is pre-filled with multi-line HTML (`div` + `ul` + `li`), so merchants editing it can easily leave a stray closing tag (e.g. an extra `</div>`).

That stray tag closes the `.woocommerce-checkout-payment` box early when jQuery parses the `update_order_review` AJAX fragment. The `.place-order` div then becomes an orphan top-level sibling that `replaceWith( '.woocommerce-checkout-payment' )` never removes, so one extra order button accumulates per update. Reproduced and control-tested in wp-env (WC 10.9.3, TT5 and YITH Wonder themes — theme-independent; block checkout is unaffected because `dangerouslySetInnerHTML` contains the imbalance).

## Changes

- `payment_fields()` now runs `force_balance_tags()` inside `wp_kses()`, so already-saved broken markup can no longer escape the payment box.
- New `validate_paidy_description_field()` (WC_Settings_API auto-dispatch) balances and kses-filters the value on save, using the same allowed-tags list as the output path.
- The allowed-tags list is extracted into a shared private `paidy_description_allowed_html()`.

## Testing

- New unit tests (`tests/Unit/test-paidy-description-balance.php`, 6 tests): stray-closing-tag removal, unclosed-tag completion, disallowed-tag stripping, default-explanation round-trip, and balanced `payment_fields()` output with both broken and empty settings.
- Full suite passes: 110 tests, 217 assertions.
- E2E in wp-env: with the previously reproducing broken setting (`<div>…</div></div>`), the checkout now always shows exactly one order button across repeated payment-method switches (before the fix: 2 → 4 buttons accumulating).
- `composer lint` clean on changed files.

## Notes

The standalone `paidy-wc` plugin has the identical code at the same line numbers and needs the same fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)